### PR TITLE
docs: add CLAUDE.md and deduplicate documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,349 @@
+# CLAUDE.md
+
+## Constitution
+
+Haytham transforms startup ideas into self-improving autonomous systems via three milestones:
+
+1. **GENESIS** (COMPLETE): Idea → working MVP. Validated with Gym Leaderboard.
+2. **EVOLUTION** (CURRENT FOCUS): Existing MVP + change request → updated, validated system. Add features, fix bugs, refactor with capability traceability.
+3. **SENTIENCE** (VISION): Running MVP with telemetry → continuous autonomous improvement.
+
+### Guiding Principles
+
+1. **Stay Focused**: Only work on features that advance the current milestone
+2. **Stay Lean**: Minimum viable implementation. No gold-plating. No premature optimization
+3. **Challenge Distractions**: If it doesn't advance the roadmap, push back. Defer polish, config options, UI enhancements, and premature abstractions
+4. **Close the Loop**: Partial solutions have no value. Complete the feedback loop
+5. **Trace Everything**: Every story traces to a capability. Every capability traces to a user need
+
+Before starting work, ask: Does this advance the current milestone? Is it the minimum viable implementation? Can it be deferred? If so, challenge the request. See [VISION.md](./VISION.md).
+
+### Meta-System Design
+
+**Haytham is a factory that produces applications.** It must handle ANY valid startup idea (web app, CLI tool, API service, marketplace), not just specific examples. This means:
+
+- **Generic prompts**: Enforce principles (traceability, consistency), not prescriptions (use Supabase, limit to 5 items). If a rule wouldn't apply to a CLI AND a web app AND an API, it's too specific.
+- **Test across input classes**: Web app, CLI tool, API service, marketplace. A fix that works for one but breaks another is not a fix.
+- **Read signals, don't hardcode**: Determine context from input rather than prescribing counts, services, or tech choices.
+- **Enforce consistency, not content**: "Every capability must trace to an IN SCOPE item" (good) vs "Output should have 5 capabilities" (bad).
+- **Self-checking agents**: Validate output against input constraints. Include SELF-CHECK sections in prompts.
+
+**Review test**: "Would this work for a CLI tool? An IoT system? A marketplace?" If no, find the generalization.
+
+### System Integrity Traits
+
+When evaluating or making changes, consider these traits critical to the system's integrity:
+
+- **Missing logical stages**: Are there gaps in the workflow where a necessary analysis or transformation step is absent?
+- **Stage handoff quality**: Is information passed cleanly between stages, or is context lost/mangled at boundaries?
+- **Information schema fit**: Is the schema between stages too tight (blocking valid inputs) or too loose (allowing garbage through)?
+- **Prompt quality**: Are agent prompts clear, well-scoped, and producing consistent results?
+- **Agent role burden**: Is any single agent overloaded with too many responsibilities? Split when a prompt tries to do too much.
+- **Agent tooling gaps**: Do agents have the tools they need to do their job, or are they forced to hallucinate what a tool should provide?
+
+---
+
+## Project Overview
+
+Haytham is a stage-based multi-agent system that validates startup ideas and generates MVP specifications. Uses a Burr-powered workflow engine to orchestrate specialist agents through four phases.
+
+## Commands
+
+```bash
+# Run
+streamlit run frontend_streamlit/Haytham.py    # or: make run
+burr                                          # Burr tracking UI (optional)
+make jaeger-up                                # Jaeger traces at localhost:16686
+
+# Development
+uv sync                                       # Install dependencies
+ruff check haytham/ && ruff format haytham/
+pytest tests/ -v                              # All tests
+pytest tests/ -k "test_stage" -v              # Pattern match
+pytest tests/ -m "not integration" -v         # Skip integration
+
+# Stage iteration
+make clear-from STAGE=market-context          # Re-run from stage
+make stages-list                              # List all stages
+make view-stage STAGE=idea-analysis           # View stage output
+make reset                                    # Clear session
+
+# Agent quality testing (ADR-018) - LLM-as-Judge evaluation
+make test-agents                              # All pilots x 2 ideas
+make test-agents-quick                        # Smoke test
+make test-agents-verbose                      # With judge reasoning
+make record-fixtures IDEA_ID=T1               # Record upstream fixtures
+
+# Setup
+cp .env.example .env                          # Then configure AWS creds + model IDs
+```
+
+## Before Every Commit (REQUIRED)
+
+**CI will fail if you skip these steps:**
+
+```bash
+uv run ruff check haytham/ --fix   # Fix lint issues
+uv run ruff format haytham/        # Format code
+uv run pytest tests/ -v -m "not integration" -x  # Run unit tests (stop on first failure)
+```
+
+Or combined: `uv run ruff check haytham/ --fix && uv run ruff format haytham/ && uv run pytest tests/ -v -m "not integration" -x`
+
+**Common failures from skipping this:**
+- Ruff formatting differences → run `uv run ruff format haytham/`
+- Unused imports or variables → run `uv run ruff check haytham/ --fix`
+- Test regressions → run `uv run pytest tests/ -v -m "not integration"` and fix
+
+---
+
+## Architecture
+
+### Four-Phase Workflow (ADR-016)
+
+- **WHY** (Idea Validation): idea_analysis → market_context → risk_assessment → [pivot_strategy] → validation_summary → GATE 1
+- **WHAT** (MVP Spec): mvp_scope → capability_model → GATE 2
+- **HOW** (Technical Design): build_buy_analysis → architecture_decisions → GATE 3
+- **STORIES** (Implementation): story_generation → story_validation → dependency_ordering
+
+**Key transitions:**
+
+```
+risk_level(HIGH) → pivot_strategy → validation_summary
+risk_level(MEDIUM|LOW) → validation_summary
+validation_complete(GO) + gate_approved → mvp_scope
+validation_complete(PIVOT) + gate_approved → idea_analysis (with pivot context)
+validation_complete(NO-GO) + gate_approved → END
+```
+
+### Key Components
+
+- **Burr Workflow** (`haytham/workflow/burr_workflow.py`): State machine with conditional branching. `when(risk_level="HIGH")` for pivot strategy.
+- **StageRegistry** (`haytham/workflow/stage_registry.py`): Single source of truth for stage metadata. O(1) lookups by slug or action name.
+- **StageExecutor** (`haytham/workflow/stage_executor.py`): Template Method Pattern. Configure via `STAGE_CONFIGS` dict.
+- **Agent Factory** (`haytham/agents/factory/agent_factory.py`): Creates agents with Strands SDK. `AGENT_FACTORIES` dict for dynamic creation.
+- **SessionManager** (`haytham/session/session_manager.py`): State, checkpoints, stage outputs. Saves to `session/{stage-slug}/`.
+- **Workflow Runner** (`frontend_streamlit/lib/workflow_runner.py`): Sync wrapper for Streamlit UI execution.
+
+**Key files:**
+- `haytham/workflow/burr_workflow.py` — Workflow definition, transitions, conditional branching
+- `haytham/workflow/burr_actions.py` — Burr action wrappers that call the stage executor
+- `haytham/workflow/stage_registry.py` — Stage metadata (slugs, phases, ordering)
+- `haytham/workflow/stage_executor.py` — `StageExecutor` class, `STAGE_CONFIGS` dict
+- `haytham/workflow/entry_conditions.py` — Entry validators, `_VALIDATORS` dict
+- `haytham/agents/factory/agent_factory.py` — Agent creation, `AGENT_FACTORIES` dict
+- `haytham/session/session_manager.py` — Session state, checkpoints, stage outputs
+- `frontend_streamlit/lib/workflow_runner.py` — `WorkflowConfig` dataclass, sync wrappers
+
+### Adding a New Agent
+
+1. Create `haytham/agents/worker_{name}/worker_{name}_prompt.txt`
+2. Add config entry in `AGENT_CONFIGS` (including structured output model if needed — don't add conditional blocks in `create_agent_by_name()`)
+3. Add factory function in `agent_factory.py` and register in `AGENT_FACTORIES`
+
+**Key files:** `haytham/agents/factory/agent_factory.py`, `haytham/agents/hooks.py`, `haytham/config.py`
+
+### Adding a New Stage
+
+1. `StageMetadata` in `stage_registry.py`
+2. `StageExecutionConfig` in `stage_executor.py`
+3. Burr action in `burr_actions.py` + transition in `burr_workflow.py`
+4. Entry validator in `entry_conditions.py` — register in `_VALIDATORS` dict and update `get_next_available_workflow()` order
+5. UI stage list in `frontend_streamlit/views/execution.py` — use `StageRegistry` for metadata, don't hardcode
+
+**Key files:** `haytham/workflow/stage_registry.py`, `haytham/workflow/stage_executor.py`, `haytham/workflow/burr_actions.py`, `haytham/workflow/burr_workflow.py`, `haytham/workflow/entry_conditions.py`, `frontend_streamlit/views/execution.py`
+
+### Adding a New Workflow Type
+
+1. Configure workflow via `WorkflowConfig` dataclass in `workflow_runner.py` — do NOT copy-paste an existing `run_*()` function
+2. Add entry validator and register in `_VALIDATORS`
+3. Add stages following the "Adding a New Stage" checklist above
+4. Update `SessionManager` workflow aliases in ONE place (extract to constant if not yet done)
+
+**Key files:** `frontend_streamlit/lib/workflow_runner.py`, `haytham/workflow/entry_conditions.py`, `haytham/session/session_manager.py`
+
+### Package Boundaries
+
+- `haytham/workflow/` imports from `haytham/agents/` — not the reverse
+- `haytham/session/` is imported by both `workflow/` and `agents/` — keep it dependency-free
+- `frontend_streamlit/lib/` wraps `haytham/` for Streamlit — never import from `frontend_streamlit/` in `haytham/`
+- `haytham/agents/output_utils.py` is the shared extraction layer — individual `worker_*/` modules import from here, not from each other
+
+## Code Hygiene Rules
+
+### DRY: Centralize Shared Logic
+
+Before defining a constant, helper, or pattern in a new file, **search the codebase** for existing definitions. Duplicate definitions rot fast.
+
+- **Shared constants**: Define once, import everywhere. Never recompute paths like `SESSION_DIR` per-file. Use `frontend_streamlit/lib/session_utils.py:get_session_dir()` for session paths.
+- **Shared initialization**: `sys.path.insert()` and `load_dotenv()` should each live in ONE init module, not be copy-pasted into every view.
+- **Shared data structures**: If a dict (like workflow aliases) or list (like stage ordering) appears in more than one place, extract it to a single source of truth — typically the relevant registry or config module.
+- **Shared formatting**: If two search providers, validators, or formatters have near-identical code, extract the common logic into a shared function/protocol.
+
+**Check**: Before adding code, grep for similar patterns. If it exists elsewhere, import it.
+
+### Single Responsibility: Keep Files and Classes Focused
+
+- **File limit**: If a file exceeds ~500 lines, it likely has multiple responsibilities. Split it.
+- **Class limit**: If a class has more than ~15 public methods, it's doing too much. Decompose into focused collaborators.
+- **Function limit**: If a function exceeds ~50 lines or handles multiple execution paths (if/elif chains for different "modes"), extract each mode into its own function or use a strategy pattern.
+
+### Open/Closed: Extend via Configuration, Not Modification
+
+When adding a new workflow, agent, stage, or search provider:
+
+- Register it in a config dict or registry — don't add another `if name == "..."` block.
+- If a function has a growing chain of `if/elif` for type dispatch, refactor to a dispatch dict or strategy pattern.
+- Structured output models for agents should be declared in `AGENT_CONFIGS` metadata, not hardcoded in conditional blocks inside `create_agent_by_name()`.
+
+### Error Handling Standards
+
+- **Never use bare `except Exception:`** that silently swallows errors. Always catch specific exceptions (`json.JSONDecodeError`, `FileNotFoundError`, `KeyError`, etc.).
+- **If a try/except pattern repeats 3+ times**, extract it into a helper (e.g., a `safe_json_load(path)` utility).
+- **Search providers** should raise/handle a common exception type, not provider-specific exceptions that leak through the abstraction.
+
+### Deprecation Policy
+
+- When deprecating code, **delete it** rather than leaving dead implementations behind commented or marked `# Deprecated`.
+- If backward compatibility requires keeping code temporarily, add a `warnings.warn()` call with a removal target date/version and create a backlog item for removal.
+- Never register deprecated implementations (validators, enum values, etc.) alongside active ones — it creates confusion about which to use.
+
+### Import Conventions
+
+- **Module-level imports only**. No `import json` or `import re` inside function bodies unless avoiding a genuine circular dependency (document the reason in a comment).
+- **Compile regex patterns at module level** if they're used in functions that may be called repeatedly.
+- **Lazy imports for optional dependencies** (telemetry, tracing) should use a module-level pattern with `TYPE_CHECKING`, not re-import on every function call.
+
+### Streamlit Frontend Conventions
+
+- **Session paths**: Use `from lib.session_utils import get_session_dir` — never compute `Path(__file__).parent...` manually.
+- **Workflow execution**: Workflow runner functions should follow a single generic pattern. When adding a new workflow type, configure it via a `WorkflowConfig` dataclass — don't copy-paste an existing `run_*()` function.
+- **Agent interaction**: Keep agent creation (factory) separate from Streamlit session state management. Factories should return agents, not mutate `st.session_state`.
+- **State queries**: Use `SessionManager` methods to check workflow state (locked, complete, etc.) — don't read lock files or stage directories directly in views.
+
+**Key files:** `frontend_streamlit/lib/session_utils.py`, `frontend_streamlit/lib/workflow_runner.py`, `frontend_streamlit/views/execution.py`
+
+### Interface Consistency
+
+- Functions/methods that serve the same role (e.g., `validate()` on entry validators) must have **identical signatures**. Never use runtime introspection (`__code__.co_varnames`) to determine how to call a method — that signals a broken interface.
+- Parallel abstractions (e.g., search result types from different providers) should share a common protocol or base class.
+
+## Key Patterns
+
+- **Strands SDK**: Agents use `strands.Agent` with prompts from `worker_*_prompt.txt`
+- **AWS Bedrock**: LLM calls via `create_bedrock_model()` with configurable timeouts
+- **Parallel Execution**: Stage 2 runs market_intelligence and competitor_analysis concurrently
+- **Structured Output**: `startup_validator` uses `structured_output_model=ValidationOutput`
+- **Session Persistence**: Checkpoints saved as markdown in `session/{stage-slug}/`
+
+**Key files:** `haytham/agents/factory/agent_factory.py`, `haytham/agents/output_utils.py`, `haytham/agents/hooks.py`, `haytham/config.py`
+
+### CRITICAL: Strands SDK Structured Output
+
+When accessing structured output from Strands agents, use `result.structured_output`, NOT `result.output`:
+
+```python
+# CORRECT - Strands SDK uses structured_output attribute
+if hasattr(result, "structured_output") and result.structured_output is not None:
+    if isinstance(result.structured_output, MyPydanticModel):
+        return result.structured_output
+
+# WRONG - This attribute doesn't exist in Strands
+if hasattr(result, "output"):  # DON'T DO THIS
+    ...
+```
+
+Reference implementation: `haytham/workflow/burr_actions.py:_extract_agent_output()`
+
+### PITFALL: Session Path Construction
+
+```python
+# WRONG — breaks across environments, duplicates logic
+session_dir = Path(__file__).parent / "../../session"
+session_dir = Path.cwd() / "session"
+
+# CORRECT — use the canonical helper
+from lib.session_utils import get_session_dir
+session_dir = get_session_dir()
+```
+
+**Key file:** `frontend_streamlit/lib/session_utils.py`
+
+### PITFALL: Agent Registration
+
+```python
+# WRONG — growing if/elif chain in create_agent_by_name()
+def create_agent_by_name(name):
+    if name == "new_agent":
+        return Agent(structured_output=MyModel)  # DON'T ADD HERE
+
+# CORRECT — declare in AGENT_CONFIGS, register factory in AGENT_FACTORIES
+AGENT_CONFIGS["new_agent"] = AgentConfig(
+    structured_output_model=MyModel,
+    ...
+)
+AGENT_FACTORIES["new_agent"] = create_new_agent
+```
+
+**Key file:** `haytham/agents/factory/agent_factory.py`
+
+### PITFALL: Entry Validator Registration
+
+```python
+# WRONG — adding elif in get_next_available_workflow()
+elif workflow_type == "new_type":
+    return validate_new_type(session)
+
+# CORRECT — register in _VALIDATORS dict
+_VALIDATORS["new_type"] = validate_new_type
+```
+
+**Key file:** `haytham/workflow/entry_conditions.py`
+
+### PITFALL: Imports Inside Function Bodies
+
+```python
+# WRONG — re-imports on every call, hides dependencies
+def process_output(result):
+    import json
+    import re
+    pattern = re.compile(r"```json(.*?)```", re.DOTALL)
+
+# CORRECT — module-level imports and compiled patterns
+import json
+import re
+
+_JSON_BLOCK_PATTERN = re.compile(r"```json(.*?)```", re.DOTALL)
+
+def process_output(result):
+    match = _JSON_BLOCK_PATTERN.search(result)
+```
+
+Exception: circular dependency avoidance (document the reason in a comment).
+
+### Logging & Privacy
+
+- **Debug/operational logging**: Use `logger.debug/info/warning/error()` via `logging.getLogger("haytham")`. Log operational metadata only — stage names, durations, token counts, file paths.
+- **User-facing output**: Stage outputs saved as markdown in `session/{stage-slug}/`. Rendered in Streamlit UI.
+- **Never log**: User's startup idea text, full LLM prompts/responses, API keys, or session state content in debug logs.
+
+### Scoring & Validation Pipeline
+
+The `validation-summary` stage runs scorer → narrator → merge sequentially. See [docs/architecture/scoring-pipeline.md](docs/architecture/scoring-pipeline.md) for the full verdict logic, dimension scoring, and post-validator details.
+
+**Key files**: `recommendation.py`, `validation_summary_models.py`, `idea_validation.py`, `worker_validation_scorer_prompt.txt`, `validators/`
+
+## Environment Variables
+
+Required: `AWS_REGION` or `AWS_PROFILE`, `BEDROCK_REASONING_MODEL_ID`, `BEDROCK_HEAVY_MODEL_ID`, `BEDROCK_LIGHT_MODEL_ID`
+
+Optional: `LOG_LEVEL`, `OTEL_SDK_DISABLED` (default: true), `OTEL_EXPORTER_OTLP_ENDPOINT` (default: localhost:4317), `DEFAULT_MAX_TOKENS` (default: 5000), `WEB_SEARCH_SESSION_LIMIT` (default: 20), `BRAVE_API_KEY` or `TAVILY_API_KEY`
+
+## Backlog.md MCP (For Generated Systems Only)
+
+**IMPORTANT:** The Backlog.md MCP tools are NOT for tracking Haytham development tasks. They are part of the system that Haytham generates — used by generated applications to manage their own task backlogs.
+
+- **DO NOT** use `mcp__backlog__*` tools to track ADR implementations, bug fixes, or feature work on Haytham itself
+- **DO** use these tools when working on the story generation or project management features that Haytham outputs for generated applications
+
+For tracking Haytham development work, use the built-in Claude Code task tools (TaskCreate, TaskUpdate, TaskList) or work directly without formal task tracking.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,77 +30,28 @@ cp .env.example .env
 
 ## Running Without AWS Credentials
 
-You don't need an AWS account to develop on Haytham. Pick one of these options:
-
-### Anthropic API
-
-```bash
-# In .env:
-LLM_PROVIDER=anthropic
-ANTHROPIC_API_KEY=sk-ant-...
-```
-
-### Ollama (Free, Local)
-
-```bash
-# Install Ollama: https://ollama.com/download
-ollama pull llama3.1:70b
-
-# In .env:
-LLM_PROVIDER=ollama
-```
-
-See [`.env.example`](.env.example) for all provider options.
+You don't need an AWS account to develop on Haytham. See [Getting Started](docs/getting-started.md#provider-setup) for Anthropic, OpenAI, and Ollama setup instructions.
 
 ## Running the App
 
 ```bash
 make run
-# Or: streamlit run frontend_streamlit/Haytham.py
-
 # Open http://localhost:8501
-```
-
-## Running Tests
-
-```bash
-# Unit tests (recommended during development)
-uv run pytest tests/ -v -m "not integration"
-
-# All tests
-uv run pytest tests/ -v
-
-# Run a specific test
-uv run pytest tests/ -k "test_stage_registry" -v
 ```
 
 ## Code Quality
 
-We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting:
-
-```bash
-# Check for lint issues
-uv run ruff check haytham/
-
-# Auto-fix lint issues
-uv run ruff check haytham/ --fix
-
-# Format code
-uv run ruff format haytham/
-```
-
-Pre-commit hooks are available to run these checks automatically:
+We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Pre-commit hooks are available:
 
 ```bash
 uv run pre-commit install
 ```
 
+See [CLAUDE.md](CLAUDE.md#before-every-commit-required) for the full lint/test/format workflow required before every commit.
+
 ## Code Conventions
 
-- See [CLAUDE.md](CLAUDE.md) for detailed architecture patterns and code hygiene rules.
-- Use the Strands SDK for agent creation. Access structured output via `result.structured_output`, not `result.output`.
-- New agents: add prompt file + config entry + factory function (see "Adding a New Agent" in CLAUDE.md).
-- New stages: add metadata + execution config + Burr action + entry validator + UI entry (see "Adding a New Stage" in CLAUDE.md).
+See [CLAUDE.md](CLAUDE.md) for architecture patterns, code hygiene rules, and checklists for adding agents/stages.
 
 ## Submitting Changes
 
@@ -147,48 +98,7 @@ For security vulnerabilities, see [SECURITY.md](SECURITY.md) — do not open a p
 
 ## Troubleshooting
 
-### `uv sync` fails with resolver errors
-
-```bash
-# Clear the cache and retry
-uv cache clean && uv sync
-```
-
-### `ModuleNotFoundError: No module named 'haytham'`
-
-Streamlit views must call `setup_paths()` before importing `haytham.*` modules:
-
-```python
-from lib.session_utils import setup_paths
-setup_paths()  # Must be first — adds project root to sys.path
-
-from haytham.workflow import ...  # Now safe
-```
-
-### Tests pass locally but fail in CI
-
-Ensure you're skipping integration tests (they require live LLM credentials):
-
-```bash
-uv run pytest tests/ -v -m "not integration"
-```
-
-### `StreamlitAPIException` or session state errors
-
-Clear the session and restart:
-
-```bash
-make reset
-make run
-```
-
-### Ruff reports lint issues
-
-The codebase should be lint-clean. If you see issues, run the full fix and format cycle:
-
-```bash
-uv run ruff check haytham/ --fix && uv run ruff format haytham/
-```
+See the [Troubleshooting Guide](docs/troubleshooting.md) for common issues and debugging tools.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Going from "I have a startup idea" to "I have a plan worth building" traditionally requires weeks of planning, domain expertise, and significant capital — with a high risk of building the wrong thing.
 
-Haytham compresses this into an evidence-based process. Twenty-one specialist agents handle the research, analysis, scoring, and generation — some working individually, others coordinating in multi-agent swarms. Humans make the decisions at every phase boundary. The output is a complete specification that any developer or coding agent can execute.
+Haytham compresses this into an evidence-based process. Specialist agents handle the research, analysis, scoring, and generation — some working individually, others coordinating in multi-agent swarms. Humans make the decisions at every phase boundary. The output is a complete specification that any developer or coding agent can execute.
 
 If the idea doesn't hold up, the system says NO-GO and tells you why. Only validated ideas proceed to specification.
 
@@ -22,16 +22,16 @@ flowchart TD
     idea --> P1
 
     subgraph genesis["Genesis — What's built today"]
-        P1["Should this be built?"] --> G1{{"👤 Founder Review"}}
+        P1["Should this be built?"] -->|Validation Report| G1{{"👤 Founder Review"}}
         G1 -->|GO| P2["What exactly?"]
-        P2 --> G2{{"👤 Product Owner"}}
-        G2 --> P3["How to build it?"]
-        P3 --> G3{{"👤 Architect Review"}}
-        G3 --> P4["What are the tasks?"]
+        P2 -->|MVP Spec| G2{{"👤 Product Owner"}}
+        G2 -->|APPROVED| P3["How to build it?"]
+        P3 -->|Architecture| G3{{"👤 Architect Review"}}
+        G3 -->|APPROVED| P4["What are the tasks?"]
     end
 
     G1 -.->|NO-GO| stop(("✋ Stop"))
-    P4 --> backlog["📋 Implementation-Ready Backlog"]
+    P4 -->|Stories| backlog["📋 Implementation-Ready Backlog"]
 
     backlog -.-> evolution["🔮 Evolution · Change Request → Updated System"]
     evolution -.-> sentience["🔮 Sentience · Telemetry → Self-Improvement"]
@@ -40,7 +40,7 @@ flowchart TD
     style sentience fill:#f5f5f5,stroke:#ccc,color:#999
 ```
 
-Twenty-one specialist agents run the analysis across four phases. A human approval gate separates each phase — the system can say NO-GO at the first gate if the idea doesn't hold up. The aim is a single control plane for the full software lifecycle. See [VISION.md](VISION.md).
+Specialist agents run the analysis across four phases. A human approval gate separates each phase — the system can say NO-GO at the first gate if the idea doesn't hold up. The aim is a single control plane for the full software lifecycle. See [VISION.md](VISION.md).
 
 ## Quick Start
 
@@ -49,10 +49,10 @@ You need Python 3.11+ and [uv](https://docs.astral.sh/uv/getting-started/install
 ```bash
 git clone https://github.com/arslan70/haytham.git
 cd haytham
-uv sync --extra anthropic
+uv sync --extra bedrock
 
 cp .env.example .env
-# Edit .env → set LLM_PROVIDER=anthropic and ANTHROPIC_API_KEY
+# Edit .env → set LLM_PROVIDER=bedrock and configure AWS credentials
 
 make run
 # Open http://localhost:8501
@@ -74,9 +74,7 @@ Feed Haytham a startup idea. What comes out:
 
 ## How It Works
 
-Four phases, each answering one question: *Should this be built? What exactly? How? What are the tasks?* A human approval gate separates each phase — nothing proceeds without your sign-off. Twenty-one specialist agents handle the analysis, research, scoring, and generation across these phases. A concept anchor preserves the original idea's identity through the entire pipeline, preventing the "telephone problem" where multi-agent handoffs silently genericize distinctive features.
-
-See [How It Works](docs/how-it-works.md) for the full walkthrough.
+Four phases, each answering one question: *Should this be built? What exactly? How? What are the tasks?* A human approval gate separates each phase — nothing proceeds without your sign-off. See [How It Works](docs/how-it-works.md) for the full walkthrough.
 
 ## Example
 
@@ -92,11 +90,7 @@ Validated end-to-end with a real startup idea:
 
 ## Technology
 
-- **Workflow Engine**: [Burr](https://github.com/dagworks-inc/burr) — A full pipeline takes 21 agents across four phases. If it fails at stage 12, one-shot systems lose everything. Burr checkpoints after every stage, so you resume where you left off. It also enables the human approval gates — pause the pipeline, review, approve or reject, then continue.
-- **Agent Framework**: [Strands Agents SDK](https://github.com/strands-agents/sdk-python) — Agents need structured output, tool use, and the ability to swap LLM providers without rewriting agent code. Strands provides a single agent interface across all providers.
-- **LLM Providers**: Anthropic, AWS Bedrock, OpenAI, Ollama — no vendor lock-in. Use a commercial API or run locally for free with Ollama.
-- **UI**: [Streamlit](https://streamlit.io/) — each phase output is a conversation. Streamlit renders the structured outputs and provides the approval gates where humans make decisions.
-- **Package Manager**: [uv](https://docs.astral.sh/uv/) — fast Python dependency management and virtual environments.
+[Burr](https://github.com/dagworks-inc/burr) (workflow engine), [Strands Agents SDK](https://github.com/strands-agents/sdk-python) (agent framework), [Streamlit](https://streamlit.io/) (UI), [uv](https://docs.astral.sh/uv/) (package manager). Supports Anthropic, AWS Bedrock, OpenAI, and Ollama — no vendor lock-in. See [Technology](docs/technology.md) for the full rationale.
 
 ## Development
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -124,32 +124,13 @@ Most agents return structured data (scores, competitor lists, story skeletons) r
 
 ### The Control Plane Pattern
 
-Haytham separates two concerns: **deciding what to build** (Phases 1-4) and **executing the build** (Phase 5+). The specification phases are Haytham's core. Execution is delegated to whatever agent or person is best suited.
+Haytham separates two concerns: **deciding what to build** (Phases 1-4) and **executing the build** (Phase 5+). The specification phases are Haytham's core. Execution is delegated to whatever agent or person is best suited — coding agents, design services, cloud service agents, or human developers. The workflow engine treats all of these the same way: same specification context, same approval gates, same traceability.
 
-The executor can be:
-
-- **A coding agent** (Devin, Amazon Q Developer Agent, Google Jules, Claude Code) receiving a story with acceptance criteria and architecture constraints
-- **A design service** (Google Stitch) receiving capability specs and generating UI code
-- **A cloud service agent** (AWS Bedrock Agents, Google Vertex AI Agents) receiving infrastructure requirements
-- **A human developer** receiving the same traced specification
-
-The workflow engine treats all of these the same way. Whether the work is done by an AI agent or a person, they receive the same specification context, participate in the same approval gates, and their output is traced back to the same capability model.
-
-### Planned: Google Stitch Integration
-
-The planned [Google Stitch](https://stitch.withgoogle.com/) integration (see [ADR-021](../adr/ADR-021-design-ux-workflow-stage.md)) will be the first demonstration of this pattern. A UX designer agent will connect to Stitch's MCP endpoint to generate UI screens, participating in the same workflow, approval gates, and traceability as every other agent.
-
-See [VISION.md](../../VISION.md#the-control-plane-orchestrating-execution-agents) for the full rationale.
+See [VISION.md](../../VISION.md#the-control-plane-orchestrating-execution-agents) for the full rationale and [Roadmap](../roadmap.md) for planned integrations (including [Google Stitch](https://stitch.withgoogle.com/) via [ADR-021](../adr/ADR-021-design-ux-workflow-stage.md)).
 
 ## Validation Pipeline
 
-At the end of Phase 1, a three-step pipeline decides whether the idea is worth building:
-
-1. **Scorer.** Checks deal-breakers, scores the idea on six dimensions, and computes a GO / NO-GO / PIVOT verdict.
-2. **Narrator.** Takes the scores and writes the report a human will read: executive summary, Lean Canvas, findings, and next steps.
-3. **Merge.** Combines the scores and the report. If the narrator accidentally states a different verdict than the scorer computed, the merge corrects it. The scorer's numbers always win.
-
-For full details, see [Scoring Pipeline](scoring-pipeline.md).
+At the end of Phase 1, a three-step pipeline (scorer → narrator → merge) decides whether the idea is worth building, producing a GO / NO-GO / PIVOT verdict. See [Scoring Pipeline](scoring-pipeline.md) for full details.
 
 ## Project Structure
 
@@ -157,7 +138,7 @@ Simplified view of the codebase. The full package includes additional modules fo
 
 ```
 haytham/
-├── agents/                  # The 21 specialist AI agents
+├── agents/                  # Specialist AI agents
 │   ├── factory/             # Creates agents on demand
 │   └── worker_*/            # One folder per agent (prompt + config)
 ├── workflow/                # Workflow engine and stage definitions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -176,12 +176,4 @@ burr
 
 ## Troubleshooting
 
-**"Module not found" errors.** Make sure you ran `uv sync` with the correct `--extra` flag for your provider.
-
-**Ollama connection refused.** Ensure Ollama is running (`ollama serve`) and the model is pulled (`ollama list`).
-
-**AWS credential errors.** Verify your AWS credentials are configured (`aws sts get-caller-identity`). Check that your IAM role has Bedrock model access in the configured region.
-
-**Incomplete or low-quality outputs.** Try a more capable model. The REASONING tier has the most impact on output quality.
-
-For logs, tracing, and more debugging tools, see the full **[Troubleshooting Guide](troubleshooting.md)**.
+Having issues? See the **[Troubleshooting Guide](troubleshooting.md)** for common errors, debugging tools, and tracing setup.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -141,7 +141,7 @@ Every story links to the capability it implements (`implements:CAP-F-001`), the 
 
 ## Agents at a Glance
 
-Twenty-one specialist agents, some working individually and others coordinating in multi-agent swarms. Swarm sub-agents are indented below their parent.
+Specialist agents, some working individually and others coordinating in multi-agent swarms. Swarm sub-agents are indented below their parent.
 
 | # | Agent | Phase | Responsibility | Frameworks |
 |---|-------|-------|----------------|------------|
@@ -188,20 +188,8 @@ Each stage output is a conversation. You can discuss the output with the system,
 
 ### Cost-Aware Design
 
-Running 21 agents with web search on a commercial API has real cost. Three mechanisms keep it manageable:
-
-**Three model tiers.** Not every agent needs the most capable model. Agents doing complex cross-referencing — validation scoring, risk assessment — use a reasoning-tier model. Agents doing substantial generation — market analysis, story writing — use a heavy-tier model. Simple classification and formatting tasks — anchor extraction, idea gatekeeper — use a lightweight model. Each tier maps to a configurable model ID, so you control the cost/quality trade-off per deployment.
-
-**Structured output.** Fifty-three Pydantic models constrain LLM responses to required fields — no wasted tokens on prose the system doesn't need. The agent returns a typed JSON object, not a free-form essay that then needs parsing. The trade-off: structured output works well for clean data structures, but for complex multi-step processes like validation scoring (which builds a scorecard incrementally through tool calls), rigid schemas are too constraining. The scorer uses tool functions instead, with each tool enforcing evidence quality as it records results.
-
-**Web search fallback chain.** Agents that need real-time data (market intelligence, competitor analysis) search the web through a provider chain: DuckDuckGo (free, no API key) is tried first, falling back to Brave Search or Tavily if it fails. A hard session-wide limit (default: 20 searches across the entire pipeline) prevents runaway loops, and agents are told in their prompts that searches are limited so they plan queries carefully. See [ADR-014](adr/ADR-014-web-search-fallback-chain.md).
+Running many agents with web search on a commercial API has real cost. Three mechanisms keep it manageable: **three model tiers** (REASONING / HEAVY / LIGHT — see [Architecture Overview](architecture/overview.md#model-tiers)), **structured output** (Pydantic models constrain LLM responses to required fields), and a **web search fallback chain** (DuckDuckGo → Brave → Tavily with session-wide limits — see [Technology](technology.md#web-search) and [ADR-014](adr/ADR-014-web-search-fallback-chain.md)).
 
 ### A Control Plane for Execution Agents
 
-Haytham's value extends beyond its own internal agents. The specification it produces — traced capabilities, architecture decisions, ordered stories — is a universal execution contract. Any agent that accepts structured work items can execute against it.
-
-**Planned:** The [Google Stitch](https://stitch.withgoogle.com/) integration (see [ADR-021](../docs/adr/ADR-021-design-ux-workflow-stage.md)) will demonstrate this. A `ux_designer` agent will connect to Stitch's MCP endpoint to generate UI screens, participating in the same workflow engine, approval gates, and traceability chains as every internal agent.
-
-**The broader pattern:** Hosted coding agents (Devin, Amazon Q Developer Agent, Google Jules, Claude Code) can receive traced stories with full specification context. Cloud-native service agents (AWS Bedrock Agents, Google Vertex AI Agents) can receive infrastructure requirements derived from architecture decisions. As more providers expose agent interfaces, the same integration path applies — without architectural changes. What varies is the executor; what stays constant is the specification-driven context and traceability.
-
-See the [Vision](../VISION.md#the-control-plane-orchestrating-execution-agents) for how this shapes each milestone.
+The specification Haytham produces — traced capabilities, architecture decisions, ordered stories — is a universal execution contract. Any agent that accepts structured work items can execute against it: coding agents, design services, cloud service agents, or human developers. See the [Vision](../VISION.md#the-control-plane-orchestrating-execution-agents) for how this shapes each milestone and the [Roadmap](roadmap.md) for planned integrations.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with architecture patterns, code hygiene rules, and developer checklists for adding agents/stages/workflows
- Deduplicate documentation across 5 files by replacing restated content with links to canonical sources
- Remove hardcoded agent counts ("21 agents") that would go stale when agents are added

## What changed

| File | Change |
|------|--------|
| `CLAUDE.md` | New file — constitution, commands, architecture, code hygiene, patterns, pitfalls |
| `CONTRIBUTING.md` | Replaced troubleshooting (5 items), provider setup, test/lint commands, and code conventions with links to `docs/troubleshooting.md`, `docs/getting-started.md`, and `CLAUDE.md` |
| `README.md` | Trimmed "How It Works" paragraph (restated diagram), condensed Technology section (restated `docs/technology.md`), removed hardcoded "Twenty-one" counts |
| `docs/how-it-works.md` | Replaced cost-aware design paragraphs and control plane section with one-sentence summaries + links to `architecture/overview.md`, `technology.md`, `VISION.md`, `roadmap.md` |
| `docs/architecture/overview.md` | Condensed validation pipeline (restated `scoring-pipeline.md`), control plane executor list (restated `VISION.md`), Google Stitch section (restated `roadmap.md`) |
| `docs/getting-started.md` | Replaced troubleshooting tips with link to `docs/troubleshooting.md` |

Net result: **-135 lines** of duplicated content replaced with links. Each topic now has one source of truth.

## Test plan

- [ ] Verify all internal markdown links resolve correctly
- [ ] Confirm `CLAUDE.md` is picked up by Claude Code as project context
- [ ] Review that no essential information was lost (only moved behind links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)