### PR TITLE
feat: add /haytham:derive-criteria (derive+calibrate) and bump to 0.3.22

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "haytham",
       "source": "./",
       "description": "Lifecycle control plane for AI-built products — validate, specify, design, build, and evolve",
-      "version": "0.3.21",
+      "version": "0.3.22",
       "repository": "https://github.com/arslan70/haytham",
       "license": "MIT",
       "keywords": [

--- a/commands/derive-criteria.md
+++ b/commands/derive-criteria.md
@@ -1,0 +1,251 @@
+---
+description: Derive a candidate telemetry contract for a capability — shape from the reasoning graph, numbers from observed reality. Output is review-ready, not authoritative; every entry has status pending until the founder approves it.
+argument-hint: <capability-id>
+allowed-tools: Read, Write, Glob, Bash, mcp__analytics-mcp__get_account_summaries, mcp__analytics-mcp__get_property_details, mcp__analytics-mcp__run_report, mcp__analytics-mcp__run_funnel_report, mcp__analytics-mcp__get_custom_dimensions_and_metrics
+---
+
+# Haytham: Derive Criteria
+
+**Version:** 0.3 (2026-05-23 — adds calibration pass: derivation now reads the project's observed baseline and proposes concrete target numbers, instead of leaving them TBD. Shape still comes from the graph; numbers come from data; approval is still the founder's.)
+
+Reads the reasoning-graph nodes for one capability, optionally queries observed reality from the analytics adapter, and produces a candidate `telemetry.derived.yml`. The criterion *shape* comes from the graph. The criterion *numbers* (targets, thresholds, sample sizes) come from the observed baseline when analytics is available, or are left as TBD when it is not. Every derived entry is `status: pending` and cites both the upstream line that justifies the shape and the observation that justifies the number. The founder then approves, modifies, or rejects each entry by editing the file.
+
+**Why this command pulls observed reality.** The honest separation of work is: the system does what it can do from data (deriving shape from the graph, calibrating numbers from baseline observations); the founder does what only a founder can do (decide whether the criterion survives, override numbers with strategic intent, add back items derivation couldn't justify). Asking the founder to fill in numbers the system could have computed is data-entry by the wrong actor.
+
+**This is a single-LLM-call command, not a multi-agent pipeline.** All derivation and calibration happens in one LLM pass with full upstream context and observed-baseline tool calls. Do not spawn sub-agents.
+
+**This command must NOT read `telemetry.yml` if one already exists for the capability.** The whole point is a clean re-derivation that can be compared against any pre-existing hand-written contract. Reading the existing file would contaminate the derivation.
+
+## Argument
+
+`$1` — the capability id (e.g. `gift-catalog`). Must match a directory under `./openspec/specs/`.
+
+## Preconditions
+
+1. Check that `./openspec/` exists. If missing:
+
+   > `openspec/` not found. Run this command from the project root that contains the reasoning graph.
+
+   Then stop.
+
+2. Check that `./openspec/specs/$1/spec.md` exists. If missing:
+
+   > Capability `$1` has no spec.md. Either the capability id is wrong or the spec hasn't been written yet.
+
+   Then stop.
+
+3. Confirm `./openspec/specs/$1/telemetry.derived.yml` does not already exist. If it does, ask the founder:
+
+   > A derived contract already exists at `./openspec/specs/$1/telemetry.derived.yml`. Overwrite it? (y/n)
+
+   If no, stop. If yes, proceed and overwrite.
+
+4. Probe whether the analytics MCP is available (look for any tool starting with `mcp__analytics-mcp__`). If available, derivation will calibrate numbers from observed baseline. If not, derivation will still run but every numeric field will be emitted as `TBD — calibrate when analytics is connected`. Note the chosen mode in the output file's header comment so the founder knows whether numbers were calibrated or left blank.
+
+5. If analytics is available, determine the property ID. Order of resolution: `./.haytham/config.yml` `ga_property_id` field, else ask the founder. Persist the value the founder provides into `./.haytham/config.yml` so subsequent runs do not re-ask.
+
+## Step 1 — Load upstream context
+
+Read into context, in this order:
+
+- `./openspec/specs/$1/spec.md` (SHALL statements and Gherkin scenarios)
+- `./openspec/context/capabilities.json` (the entry whose id matches `$1`, plus its acceptance criteria)
+- `./openspec/context/concept-anchor.json` (invariants and strategic signals — filter to ones that touch this capability)
+- `./openspec/context/architecture-decisions.json` (decisions that constrain what's measurable for this capability)
+- `./openspec/context/competitor-research.md` (only the sections relevant to this capability's dimension of competition)
+
+Do **not** read `./openspec/specs/$1/telemetry.yml` even if it exists.
+
+If any of these files is missing, note it in the derived output as an `intent_gap` comment at the top of the file and continue with what's available.
+
+## Step 2 — Derive entries (SINGLE LLM PASS)
+
+This is the only reasoning step. Hold the entire upstream context in mind and produce a candidate `telemetry.derived.yml`. The pass has two phases inside one LLM turn:
+
+**Phase A — Derive shape.** From the upstream graph alone, decide which criteria, anti-signals, and events the capability needs. Follow Rules 1–7 below. The output of this phase is the criterion *shape*: name, definition, dimensions, derivation_notes, derived_from citations. Numbers are not set yet.
+
+**Phase B — Calibrate (only if analytics is available).** For each derived criterion, run the GA4 queries its definition implies. Use `run_funnel_report` for any threshold whose definition describes sessions doing X then Y (per the same rules in `/haytham:propose-next-steps` Step 2). Use `run_report` only for pure aggregations. Last-30-day window unless the capability dictates otherwise. Compute the observed baseline. Then propose a calibrated target per Rule 6's policies (floor / stretch / invariant). Run queries in parallel where possible (single message, multiple tool calls). If a query fails, emit `observed_baseline: {query_succeeded: false, error: <message>}` and `target: "TBD — query failed; founder to set"` for that entry — never invent a number to paper over a failed query.
+
+If analytics is unavailable, skip Phase B entirely and emit shape-only output (numbers as TBD strings, no observed_baseline blocks).
+
+Follow these rules. They are hard constraints.
+
+**Rule 1 — Every entry must cite an upstream line.** Each derived entry has a `derived_from` field listing the specific upstream artifact and line(s) that justify it. Example: `derived_from: ["openspec/specs/gift-catalog/spec.md:7-9 (CAP-F-001 SHALL statement)", "openspec/context/capabilities.json#gift-catalog.acceptance_criteria[0]"]`. An entry without a traceable citation is not allowed. If you cannot point to a specific upstream line, do not emit the entry.
+
+**Rule 2 — Do not invent criteria.** If a SHALL statement or scenario does not imply a measurable success or failure, do not produce a criterion for it. Skipping is correct. The job is to derive, not to reach.
+
+**Rule 2a — Events are schema, not criteria.** Events under `events:` are the measurement schema needed to populate the `success_thresholds` and `anti_signals` you emit. Emit an event when a threshold or anti-signal requires it. Do not emit events that no derived criterion uses. Events are not subject to Rule 2's "do not invent" bar in the same way criteria are — they are the *implied dimensions* of the criteria you derive.
+
+**Rule 3 — Skip observation data.** Do not generate `baseline_snapshot`, `fired_today` flags, or any field that requires a live measurement. Those come from `propose-next-steps`, not from derivation. The derived file is the hypothesis. Observations are layered on later.
+
+**Rule 4 — Skip runtime state.** Do not generate `version`, `revisions`, or any field that tracks contract history. The derived file is a fresh candidate. Versioning is added at approval time.
+
+**Rule 5 — Status is always pending.** Every entry (each event, each success_threshold, each anti_signal, etc.) has `status: pending`. The founder edits this after reviewing.
+
+**Rule 6 — Shape comes from the graph; numbers come from data.** A derived threshold like `target: ">= 12%"` cannot be justified by a SHALL statement (SHALL statements don't contain numbers). Derive the *shape* of the criterion ("of catalog-landing sessions, the fraction that reach a product detail page") from the graph. Then, if analytics is available, run the queries the shape implies against the last 30-day window, record the observed value as the baseline, and propose a calibrated target. Calibration policy:
+
+- **Minimum-acceptable / floor thresholds** (where the SHALL describes something the system *must* do, e.g. "primary discovery mechanism"): target = observed baseline, rounded down to a "don't regress" floor. Confidence: medium.
+- **Stretch / target thresholds** (where the upstream implies a goal, e.g. competitive differentiation): target = observed baseline + a modest lift the proposer can argue for from competitor data or strategic signals. Confidence: low.
+- **Correctness / invariant thresholds** (where a SHALL is unconditional, e.g. "every product detail page must have these elements"): target = 100% (or 0 for negative SHALLs). Confidence: high. Do not compute from baseline — the SHALL itself sets the number.
+
+Emit `observed_baseline: {value, window, sample_n, query_succeeded}` on every entry where analytics ran. Emit `calibration_rationale: |` on every entry explaining which policy applied and why the proposed number reflects it. If analytics is unavailable, emit `target: "TBD — calibrate when analytics is connected"` and skip the baseline/rationale.
+
+**Rule 7 — Skip differentiation entries unless a specific competitor is paired with a specific dimension in one citation.** A `differentiates_from` entry requires a single upstream citation that names both a competitor (by name, not by category — "TCS SentimentsExpress" qualifies, "Pakistani gifting sites" does not) and the dimension on which this capability differentiates from that competitor. Two separate citations (a competitor mentioned in one place, a dimension mentioned in another) do not pair. Generic competitive intuition is not allowed. If the strategic signal is real but the citation isn't paired in one place, emit no entry and add an `intent_gaps` note saying the concept-anchor should be enriched.
+
+## Step 3 — Write the derived file
+
+Path: `./openspec/specs/$1/telemetry.derived.yml`.
+
+Shape (omit any section that has zero derived entries):
+
+```yaml
+# Derived telemetry candidate for the $1 capability.
+# Generated by /haytham:derive-criteria on <ISO-timestamp>.
+# Every entry below is status: pending. Edit this file to approve,
+# modify, or reject. The proposer (/haytham:propose-next-steps) reads
+# only entries with status: approved or status: modified.
+
+capability: $1
+spec_ref: openspec/specs/$1/spec.md
+derived_at: <ISO-timestamp>
+calibration_mode: <"calibrated" if analytics available, else "shape-only">
+
+# Baseline observations used to calibrate the numbers below. Omit this
+# entire block in shape-only mode. If a future re-derivation produces
+# different baseline numbers, that drift is itself a signal — preserve
+# the original here and append the new run below.
+baseline_snapshot:
+  measured_at: <ISO-date>
+  window: last_30_days
+  property_id: <ga4 property id>
+  totals:
+    <metric_name>: <value>
+    ...
+  derived:
+    <ratio_name>: <value>
+    ...
+
+purpose: |
+  <Derived from spec.md Purpose section. One paragraph. Verbatim
+  or near-verbatim from the spec; do not paraphrase the founder's
+  intent into something looser.>
+purpose_derived_from:
+  - openspec/specs/$1/spec.md#Purpose
+
+events:
+  - id: <event-name>
+    status: pending
+    description: <what this event represents>
+    dimensions: [<dimension list needed to populate the criteria below>]
+    derived_from:
+      - <upstream citation>
+    derivation_notes: |
+      <Why this event is needed — which SHALL or scenario implies
+      it. Do not include fired_today; that is observed at runtime.>
+
+success_thresholds:
+  - name: <criterion-name>
+    status: pending
+    definition: |
+      <The shape of the measurement, derived from the SHALL or scenario.
+      Numerator/denominator phrased session-scoped where applicable.>
+    target: "<calibrated number per Rule 6, e.g. '>= 20%'; or 'TBD —
+      calibrate when analytics is connected' in shape-only mode>"
+    derived_from:
+      - <upstream citation>
+    derivation_notes: |
+      <What kind of threshold this is per Rule 6: minimum-acceptable
+      floor, stretch target, or correctness invariant. Why the upstream
+      implies this classification.>
+    observed_baseline:                    # omit in shape-only mode
+      value: <observed value>
+      window: last_30_days
+      sample_n: <denominator size>
+      query_succeeded: true
+    calibration_rationale: |              # omit in shape-only mode
+      <Which Rule 6 policy applied (floor / stretch / invariant) and how
+      the proposed number reflects it. One to three sentences.>
+
+anti_signals:
+  - name: <anti-signal-name>
+    status: pending
+    definition: |
+      <The failure mode, derived from a scenario or invariant. What it
+      looks like in measurable form.>
+    threshold: "<calibrated number per Rule 6; or 'TBD — calibrate when
+      analytics is connected' in shape-only mode>"
+    derived_from:
+      - <upstream citation>
+    derivation_notes: |
+      <Why this is a failure mode according to the upstream. What in the
+      spec is violated when this fires.>
+    observed_baseline:                    # omit in shape-only mode
+      value: <observed value>
+      window: last_30_days
+      sample_n: <denominator size>
+      query_succeeded: true
+    calibration_rationale: |              # omit in shape-only mode
+      <Which Rule 6 policy applied and how the threshold reflects it.>
+
+regression_triggers:
+  - text: |
+      <Phrase as a sentence. Each trigger must derive from a specific
+      upstream invariant or scenario. Avoid generic "drop in metric X"
+      triggers unless the upstream implies a slope.>
+    status: pending
+    derived_from:
+      - <upstream citation>
+
+minimum_sample:
+  status: pending
+  value: <calibrated weekly sample floor — see rationale; or
+    "TBD — calibrate when analytics is connected" in shape-only mode>
+  rationale: |
+    <In calibrated mode: derive the floor from observed weekly traffic
+    volume for the capability's denominator population. Floor should be
+    high enough to gate out single-week noise spikes but low enough to
+    run at current traffic. State the observed weekly value and the
+    fraction you chose.
+    In shape-only mode: emit verbatim "Cannot derive without observed
+    traffic. Founder or next calibration pass to set."
+    Always keep this section — the founder needs a place to record the
+    number at approval time.>
+  observed_baseline:                    # omit in shape-only mode
+    weekly_sessions_in_window: <value>
+    window: last_30_days
+  derived_from:
+    - <upstream citation if the graph constrains the floor, otherwise
+      the string "calibrated from observed traffic">
+
+differentiates_from:
+  - competitor: <name>
+    dimension: <name>
+    status: pending
+    notes: |
+      <Verbatim or near-verbatim from concept-anchor.json strategic
+      signals or competitor-research.md. Do not synthesize.>
+    derived_from:
+      - <upstream citation>
+
+# intent_gaps: optional. Comment-list of upstream nodes that were
+# missing or that the derivation could not reason against. Example:
+# - "openspec/context/competitor-research.md not found — competitive
+#    differentiation entries skipped"
+```
+
+## Step 4 — Present the derivation summary
+
+After writing the file, print to the user:
+
+- The full path of the written file.
+- One-line counts: N success_thresholds, N anti_signals, N events, N differentiates_from entries, N regression_triggers.
+- Whether any sections were skipped (and why).
+- A reminder: every entry is `status: pending`. The founder reviews and edits the file directly. The proposer will only read `approved` and `modified` entries.
+
+End with:
+
+> Open `./openspec/specs/$1/telemetry.derived.yml`, review each entry, and change `status: pending` to `status: approved` (or `modified` with edits, or `rejected` with a reason). When you're done, run `/haytham:propose-next-steps` to see how the proposals change.
+
+## Step 5 — Stop
+
+Do not auto-run `propose-next-steps` after derivation. The approval gate is the whole point of v1.

--- a/commands/propose-next-steps.md
+++ b/commands/propose-next-steps.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write, Glob, Bash, TodoWrite, mcp__analytics-mcp__get_accou
 
 # Haytham: Propose Next Steps
 
-**Version:** 0.1 (2026-05-17 — prompt improvements from the cold-proxy test)
+**Version:** 0.2 (2026-05-23 — reads `telemetry.derived.yml` when present and filters entries by approval status; legacy `telemetry.yml` still supported for capabilities that haven't migrated)
 
 Closes the reasoning-graph loop. Read the project's telemetry contracts, pull live observed values from the configured adapter, fold in the latest strategic context, and produce a ranked list of change candidates the founder can route to `/haytham:evolve`.
 
@@ -32,9 +32,9 @@ Mark `in_progress` when each step starts and `completed` when its output exists.
 
    Then stop.
 
-2. Glob `./openspec/specs/*/telemetry.yml`. If zero matches:
+2. Glob `./openspec/specs/*/telemetry.derived.yml` and `./openspec/specs/*/telemetry.yml`. A capability has a contract if either matches. If the union is empty:
 
-   > No telemetry contracts found. Run `/haytham:propose-next-steps` after writing at least one `openspec/specs/<capability>/telemetry.yml`. The contract is what makes the loop possible; without it the proposer would be guessing.
+   > No telemetry contracts found. Either run `/haytham:derive-criteria <capability>` to produce a candidate contract from the reasoning graph, or hand-write at least one `openspec/specs/<capability>/telemetry.yml`. The contract is what makes the loop possible; without it the proposer would be guessing.
 
    Then stop.
 
@@ -57,8 +57,12 @@ Read into context:
 - `./openspec/context/concept-anchor.json` (project invariants and strategic signals)
 - `./openspec/context/capabilities.json` (capability model)
 - `./openspec/context/architecture-decisions.json` (build/buy choices and constraints)
-- Every `./openspec/specs/*/telemetry.yml` returned by the glob
+- For each capability that has a contract: prefer `./openspec/specs/<capability>/telemetry.derived.yml` if it exists; otherwise fall back to `./openspec/specs/<capability>/telemetry.yml`. Never read both for the same capability — the derived file is authoritative when present.
 - For each capability that has a contract, also read its `./openspec/specs/<capability>/spec.md` (the Gherkin scenarios and SHALL statements)
+
+**Filter by approval status (derived files only).** For each contract loaded from `telemetry.derived.yml`, filter every list field (`events`, `success_thresholds`, `anti_signals`, `regression_triggers`, `differentiates_from`) to keep only entries whose `status` is `approved` or `modified`. Drop `pending` and `rejected` entries silently — the proposer must not reason against unapproved hypotheses. If after filtering a capability has zero entries across all lists, treat it as `unapproved` and surface an `intent_gap` finding in Step 4: `intent_gap: <capability> — derivation exists but no entries approved yet`. Do not query observed reality for unapproved capabilities.
+
+Legacy `telemetry.yml` files have no `status` field; treat all their entries as approved by default. This preserves existing behaviour for capabilities that haven't been migrated to the derive-and-approve flow.
 
 If any context file is missing, note it in the proposals output as `intent_gap` — don't stop.
 

--- a/docs/plans/2026-05-18-polymorphic-telemetry-contracts.md
+++ b/docs/plans/2026-05-18-polymorphic-telemetry-contracts.md
@@ -1,0 +1,287 @@
+# Plan: Polymorphic telemetry contracts (derived + approved)
+
+**Date:** 2026-05-18
+**Status:** Design proposal, pre-build
+**Milestone:** SENTIENCE (foundational)
+**Supersedes for telemetry concerns:** 2026-05-16-propose-next-steps.md (the proposer survives; the contract shape it reads needs to be rebuilt)
+
+## Goal
+
+Replace today's hand-written, single-shape `telemetry.yml` with a polymorphic contract that:
+
+1. Is **derived** by the system from the upstream reasoning graph (concept-anchor, capability spec, mvp-scope, architecture decisions), then **gated by founder approval**.
+2. Supports **multiple measurement frameworks** per capability, so capabilities that don't fit a funnel shape (trust signals, internal tools, non-functional invariants) can be measured honestly instead of pretzel-shaped.
+3. Treats **cross-platform** (web, mobile, anything else) as an adapter-and-vocabulary concern, not a fundamental contract-shape concern.
+
+Without this, the SENTIENCE loop is mostly synthetic: the proposer "discovers" gaps the founder pre-annotated, and only works for the one capability whose measurement style happens to match the current contract format.
+
+## Why now
+
+Three things converged that exposed the current design's limits.
+
+**One.** The first end-to-end loop run (2026-05-17) demonstrated the engineering closes, but on audit, every "finding" the system surfaced was something the founder had hand-annotated into `telemetry.yml` a day earlier. The proposer relayed; it didn't reason. See [docs/blog/posts/2026-05-18-can-you-ask-claude-code-to-improve-your-system.md](../blog/posts/2026-05-18-can-you-ask-claude-code-to-improve-your-system.md) for the public version; the cheating audit was sharper than the blog admits.
+
+**Two.** A polished sentence in that blog post ("the success threshold my contract used to judge this capability depended on a measurement that wasn't actually being captured, so the system couldn't tell whether the capability was working") triggered the right question: *which agent actually did that work?* Answer: none. The contract author did. The system surfaced an annotation.
+
+**Three.** Walking through the existing GiftKaro capabilities surfaced that `telemetry.yml` only fits the one capability we've used it on. Trust signals (CAP-F-004) measure indirectly via A/B uplift. Admin management (CAP-F-005) is operator-grade, not funnel-shaped. Mobile-responsive (CAP-NF-001) is a manual checkpoint. USD accuracy (CAP-NF-003) is an invariant. The current shape forces all of them into "success_thresholds with targets," which produces low-leverage criteria for everything except user-flow capabilities on web.
+
+The fix is one design move with three parts.
+
+## The shape of the redesign
+
+### Part 1 — Derive, don't declare
+
+Success criteria for a capability are **inferred** by `/haytham:derive-criteria` from upstream graph nodes, not hand-written by the founder. Each inferred entry carries a `derived_from[]` provenance trace (which source files, which acceptance criteria, which strategic signals contributed) and an `approval` state machine (`pending` → `approved` | `modified` | `rejected`).
+
+The founder reviews proposed criteria via `/haytham:approve-criteria`. Accepted entries become the active contract. Modifications are recorded with `founder_note`. Rejections stick (re-derivation won't keep re-proposing rejected entries unless evidence has changed).
+
+The `telemetry.yml` file is the persistent record of approved criteria plus their provenance. It is not a source of truth; the source of truth is the upstream graph. The file is a cache the proposer reads.
+
+### Part 2 — Polymorphic frameworks
+
+A capability has zero or more **aspects**. Each aspect uses one of six frameworks:
+
+| Framework | When to use | Core fields |
+|---|---|---|
+| `funnel` | Sequential user flows | `steps[]`, `target`, `anti_signals` |
+| `sli` | Latency / error rate / availability / crash-free rate / retention metrics | `metric`, `target`, `window` |
+| `invariant` | Must-be-true properties | `property`, `check_via`, `fires_when` |
+| `ab_attribution` | Indirect effects (UX, trust, persuasion) | `variants`, `outcome`, `attribution_window` |
+| `usage_and_error` | Internal tools, low-volume capabilities | `usage_signals[]`, `error_signals[]` |
+| `qualitative_checkpoint` | Things the system can't quantify | `check_procedure`, `check_interval`, `last_result` |
+
+Six covers what I can see today. A seventh (probably `reputation` for app-store ratings, NPS, review sentiment) might be added when a mobile-first project needs it. Defer until a real capability resists all six.
+
+A capability can have multiple aspects. Catalog might have both `funnel` (does it convert?) and `sli` (does it render in time?). The aspects list is just a list; composition is at the list level.
+
+### Part 3 — Cross-platform as adapter detail
+
+Platforms are declared at the project level. Each aspect refers to logical events, not provider-specific names. An adapter resolves logical events to provider queries per platform at query time.
+
+Two new project-level concerns:
+
+- **Platforms declared in `concept-anchor.json`** as a new top-level field (`"platforms": ["web", "mobile_ios"]`). Founder-owned strategic fact.
+- **Adapter config in `.haytham/adapters.yml`** (per-project, per-platform). Operator-owned. Carries provider IDs, query endpoints. Separate from strategic intent because the lifecycles are different.
+- **Logical-event vocabulary in `openspec/event-vocabulary.yml`** with per-platform mappings. Bootstrapped by `/haytham:derive-vocabulary` (scans spec files, proposes default mappings, founder confirms).
+
+A capability declares `applies_to_platforms: [web, mobile_ios]`. The proposer queries each applicable platform separately and surfaces large per-platform deltas as candidates.
+
+## Concrete shape: worked examples
+
+Three examples chosen to span the polymorphism. Same capability scaffold (`capability`, `spec_ref`, `applies_to_platforms`, `derivation`, `aspects`, `differentiates_from`, `observations`); the aspect contents differ by framework.
+
+### Example A — `gift-catalog` (funnel + SLI)
+
+```yaml
+capability: gift-catalog
+spec_ref: openspec/specs/gift-catalog/spec.md#CAP-F-001
+applies_to_platforms: [web]
+
+derivation:
+  last_run: 2026-05-19T01:23:00Z
+  inferred_from:
+    - openspec/context/concept-anchor.json
+    - openspec/context/capabilities.json#CAP-F-001
+    - openspec/specs/gift-catalog/spec.md
+
+aspects:
+  - framework: funnel
+    name: catalog_to_product_conversion
+    steps:
+      - event: catalog_landing
+      - event: view_item
+    target: ">= 12%"
+    anti_signals:
+      - name: collapse
+        condition: "step2/step1 < 5% over 7d"
+    derived_from:
+      - source: openspec/specs/gift-catalog/spec.md
+        cite: "Acceptance: Selecting a category navigates to ... each bundle links to a product detail page."
+        why: |
+          The capability's job is moving buyers from category tile to
+          product detail. That's the natural funnel.
+      - source: openspec/context/concept-anchor.json
+        cite: strategic_signals.success_metric = "revenue"
+        why: |
+          Revenue decomposes through orders → checkout → product views;
+          this capability owns the product-views step.
+    approval: { state: approved, reviewed_at: 2026-05-19 }
+
+  - framework: sli
+    name: catalog_render_time
+    metric: largest_contentful_paint_p75
+    target: "< 2500ms"
+    window: 7d
+    derived_from:
+      - source: openspec/specs/gift-catalog/spec.md
+        cite: "diaspora buyers mostly land from social ads on mobile browsers"
+        why: |
+          Catalog conversion only matters if pages render before the buyer
+          loses patience. LCP under 2.5s is the standard mobile threshold.
+    approval: { state: pending }
+```
+
+### Example B — `trust-signals` (A/B attribution + invariant)
+
+The capability that motivated polymorphism. Funnel framing doesn't work because the effect is indirect.
+
+```yaml
+capability: trust-signals
+spec_ref: openspec/specs/trust-signals/spec.md#CAP-F-004
+applies_to_platforms: [web]
+
+aspects:
+  - framework: ab_attribution
+    name: trust_signal_uplift
+    variants:
+      a: trust_signals_visible_above_fold
+      b: trust_signals_hidden
+    outcome:
+      event: begin_checkout
+      attribution_window: same_session
+    target_uplift: ">= 10% relative"
+    derived_from:
+      - source: openspec/context/competitor-research.md
+        cite: "Trustpilot widget praised when present; rare among competitors"
+        why: |
+          The competitive evidence says trust signals move conversion when
+          present. If the wedge is real, an A/B should show uplift.
+    approval: { state: pending }
+
+  - framework: invariant
+    name: trust_band_visible_on_load
+    property: |
+      On catalog and product detail pages, the trust-signal band must be
+      rendered above the fold on both 375px and 1280px viewports.
+    check_via: visual_regression_test
+    fires_when: violated
+    derived_from:
+      - source: openspec/specs/trust-signals/spec.md
+        cite: acceptance criteria
+        why: |
+          If the signals load below the fold, they don't influence the
+          decision. The capability's job depends on the invariant.
+    approval: { state: pending }
+```
+
+### Example C — `admin-catalog-management` (usage + qualitative)
+
+The operator-grade capability that doesn't have a user funnel at all.
+
+```yaml
+capability: admin-catalog-management
+spec_ref: openspec/specs/admin-management/spec.md#CAP-F-005
+applies_to_platforms: [web]
+
+aspects:
+  - framework: usage_and_error
+    name: admin_operations
+    usage_signals:
+      - event: admin_bundle_created
+        target: "at least 1 per week"
+      - event: admin_bundle_edited
+        target: "any positive rate"
+    error_signals:
+      - event: admin_action_error
+        threshold: "< 2% of admin sessions"
+    derived_from: [...]
+    approval: { state: pending }
+
+  - framework: qualitative_checkpoint
+    name: admin_friction_review
+    check_interval: monthly
+    check_procedure: |
+      Founder runs a typical bundle update end-to-end, notes any friction
+      the metrics don't show (slow loads, confusing copy, missing fields).
+    derived_from:
+      - source: openspec/context/concept-anchor.json
+        cite: founder_intent.constraints.team = "small"
+        why: |
+          Admin is operator-grade for one person. Quantitative measurement
+          misses the actual concern: does it slow the founder down.
+    approval: { state: pending }
+```
+
+## The derivation pipeline
+
+```
+For each capability:
+  1. Read spec, concept-anchor, mvp-scope, architecture-decisions.
+  2. Classify: which frameworks apply?
+       user-flow gestures + acceptance criteria → funnel
+       non-functional measurement field → sli or invariant
+       indirect persuasion / UX → ab_attribution
+       internal / operator-grade → usage_and_error + qualitative
+       anything unquantifiable → qualitative_checkpoint
+  3. Determine platform applicability from spec + project platforms.
+  4. For each (framework, platform) pair, derive aspect candidates with
+     full derived_from provenance.
+  5. Write candidates to telemetry.yml with approval.state = pending.
+```
+
+The classification step is real reasoning the system has to do, and it can be wrong. That's why the approval gate exists. If the system classifies trust-signals as `funnel` (wrong) and the founder reviews and rejects, the rejection plus reason becomes part of the contract's history, and re-derivation reads that history before proposing again.
+
+## Three new commands
+
+- **`/haytham:derive-criteria <capability>`** — reads upstream graph nodes for the capability, classifies, derives aspect candidates per framework, writes them to `telemetry.yml` with `approval.state = pending`. Prints the diff.
+- **`/haytham:approve-criteria <capability>`** — interactive walk-through of pending entries. Founder accepts each, modifies each, or rejects each with reason. Sets approval state.
+- **`/haytham:derive-vocabulary [logical_event_name]`** — scans spec files for event references, reads platforms from concept-anchor, proposes default mappings, founder confirms.
+
+`/haytham:propose-next-steps` doesn't change much in surface but changes in behavior: it now reads **only approved aspects** from the contract. Pending and rejected entries are visible in the file but not load-bearing for proposal logic.
+
+## Migration
+
+The existing `gift-catalog/telemetry.yml` v3 doesn't get hand-restructured. It gets **re-derived**:
+
+1. Move v3 to `telemetry.legacy.yml` for reference (one-time, manual).
+2. Run `/haytham:derive-criteria gift-catalog`. This produces a polymorphic version with `approval.state = pending` on every aspect.
+3. Compare the derived version against the legacy version. The derived version's `funnel` aspect should look very similar to the legacy `success_thresholds`. Any divergence is informative — either the legacy was wrong, or the derivation is wrong, or both are valid framings the founder needs to pick between.
+4. Founder approves (or modifies, or rejects) each aspect.
+5. Delete `telemetry.legacy.yml` once parity (or chosen divergence) is confirmed.
+
+The "compare derivation against my hand-written v3" step is also **the test of the architecture**. If the derived version is materially worse than what I wrote by hand, the derivation prompt isn't doing enough work. That's a finding before we ship.
+
+## Decisions made (during 2026-05-18 design walkthrough)
+
+1. **Six frameworks, not more, not fewer.** Add a seventh only when a real capability resists all six. Likely candidate: `reputation` for app-store ratings / NPS.
+2. **`qualitative_checkpoint` is a framework, not a meta-flag.** Compose at the aspect-list level. Don't introduce a `qualitative_supplements[]` field on every aspect.
+3. **Cross-platform mismatches: per-platform observation, proposer judges what to surface.** No declared `platform_parity` field. If parity is genuinely required, express it in the capability spec.
+4. **Platform list in `concept-anchor.json`; adapter config in `.haytham/adapters.yml`.** Different lifecycles, different owners.
+5. **`event-vocabulary.yml` is derive-bootstrapped + grows incrementally.** Missing entries cause the proposer to fail fast and prompt for a mapping.
+
+## Open questions / risks
+
+- **Classification can be wrong.** The hardest reasoning step is deciding which framework(s) apply. Mitigation: founder approval gate; provenance trace; re-derivation can be re-run when wrong classification is corrected.
+- **The `derive-criteria` prompt is non-trivial.** It has to do real reasoning over multiple files, classify, then produce structured output per framework. Risks: hallucinated criteria, missed frameworks, sloppy `derived_from` citations. The cold-proxy test method we used for `/haytham:propose-next-steps` applies here too.
+- **Approved aspects vs reality drift.** A founder approves an aspect today. Six months later the spec changes but the approved aspect doesn't. The provenance trace makes the staleness visible (the citation now points to text that has been edited), but we need a "re-derive when sources have changed" hook. Defer to v0.2.
+- **The `event-vocabulary.yml` chicken-egg.** First-time setup requires the founder to know event names. Can be eased with `derive-vocabulary` but the spec has to reference events for the derivation to work. Mitigation: when the spec doesn't name events, the derivation should propose canonical names per framework defaults (e.g., funnel steps default to `step_<n>` placeholders).
+- **The legacy `gift-catalog` contract may be hard to compare cleanly.** Some of v3's fields (`baseline_snapshot`, `revisions`) have no direct analog in the new shape. Mapping them to the new structure is a manual exercise. One-time cost.
+
+## Sequencing
+
+Five phases. Each is shippable on its own.
+
+1. **Schema design + worked examples for all six frameworks.** No code. Just the contract spec written down as JSON Schema (or equivalent) so future agents can validate output. Probably ~1 day.
+2. **`/haytham:derive-criteria` for one capability.** Pick `trust-signals` (it's the one where the current shape fails hardest — clearest signal of polymorphism payoff). Manual review of output. No `approve-criteria` command yet; founder edits the file by hand to flip approval states. Probably 2-3 days.
+3. **`/haytham:approve-criteria` command.** Interactive walk-through; persists approval state. Probably 1-2 days.
+4. **Update `/haytham:propose-next-steps`** to read approved-only aspects. The proposer logic per-framework — comparing observations to `funnel` targets vs `sli` thresholds vs `invariant` violations vs `ab_attribution` outcomes — is real work. Probably 3-5 days.
+5. **Cross-platform / vocabulary / adapters.** Defer until we have a real mobile project. The schema supports `applies_to_platforms` from day one but the runtime dispatch can wait. When needed, build `/haytham:derive-vocabulary` and the adapter dispatch logic. Probably a week when triggered.
+
+Phases 1-4 are the v1 deliverable. Phase 5 is on-demand.
+
+## What this plan deliberately defers
+
+- **Automated re-derivation on source changes.** Out of v1. Founders run `derive-criteria` when they want to re-check.
+- **The seventh framework (reputation).** Until a project needs it.
+- **Multi-project vocabulary sharing.** Each project has its own vocabulary file in v1. Could become a shared registry later.
+- **Audit history of approval changes.** Approval state is current-snapshot in v1. Git history is the audit trail.
+
+## Definition of done for v1
+
+- `/haytham:derive-criteria trust-signals` produces a polymorphic contract for GiftKaro's trust-signals capability with at least two aspects across two frameworks, all entries with full `derived_from` traces.
+- `/haytham:approve-criteria trust-signals` walks the founder through pending entries; founder ends the session with at least one approved, one modified, and one rejected aspect.
+- `/haytham:propose-next-steps` reads only approved aspects from the trust-signals contract and produces (or correctly refuses to produce, per the minimum-sample gate) a proposal.
+- The existing `gift-catalog` v3 contract is re-derived; the derived version's funnel aspect is within "obvious agreement" of the legacy `success_thresholds` (modulo refactoring for the new shape). Any meaningful divergence is documented as a finding.
+- Plugin sanity tests pass, including schema validation for the new contract shape.
+
+When all five are true, the SENTIENCE loop has actually closed on something the system reasoned about, not something the founder pre-annotated. That's the real first version.

--- a/docs/plans/2026-05-22-derive-and-approve-criteria.md
+++ b/docs/plans/2026-05-22-derive-and-approve-criteria.md
@@ -1,0 +1,102 @@
+# Derive-and-Approve Criteria (Lean v1)
+
+**Date:** 2026-05-22
+**Supersedes:** `2026-05-18-polymorphic-telemetry-contracts.md` (deferred — see bottom)
+
+## Goal
+
+Make success criteria honest for Haytham-built products by removing the two sources of dishonesty in the current `telemetry.yml`:
+
+1. The founder hand-writes the criteria, so they can drift from spec or be set on aspiration.
+2. The proposer reasons against whatever criteria exist, with no gate, so hallucinated or stale criteria silently become authority.
+
+The fix is two changes: **derive the criteria from upstream graph nodes** and **gate them through founder approval** before the proposer can use them.
+
+## Scope
+
+One capability: `gift-catalog`. We already have the hand-written `telemetry.yml` v3 to compare against. If the derive-and-approve loop produces a more honest set than v3, the loop works. If not, we know what specifically broke.
+
+Everything else (polymorphism, six frameworks, error budgets, cross-platform vocabulary, adapter dispatch, audit history) is deferred until evidence asks for it.
+
+## What changes
+
+### 1. New command: `/haytham:derive-criteria <capability>`
+
+Reads upstream graph nodes and produces a candidate criteria set. No new schema. Output is a YAML file in the same shape as the current `telemetry.yml`, but every entry has `status: pending` and a `derived_from` block citing the specific upstream lines that justify it.
+
+Inputs the command reads:
+- `openspec/specs/<capability>/spec.md` (SHALL statements and Gherkin acceptance criteria)
+- `openspec/context/capabilities.json` (capability id, description, acceptance criteria)
+- `openspec/context/concept-anchor.json` (invariants and strategic signals that touch this capability)
+- `openspec/context/architecture-decisions.json` (build/buy choices that affect what's measurable)
+
+Output path: `openspec/specs/<capability>/telemetry.derived.yml`. Separate file from the existing contract so we can diff them.
+
+Single LLM call, no sub-agents (per CLAUDE.md pitfall). The prompt's job: for each acceptance criterion or SHALL statement, propose a measurable criterion if one is justified, and skip if not. Every proposed criterion must cite the upstream line it came from. Criteria not traceable to a specific upstream line are not allowed.
+
+### 2. Approval as a YAML field, not a command
+
+Every criterion in `telemetry.derived.yml` has `status: pending`. The founder approves by editing the file: change `pending` to `approved`, `modified` (and edit the criterion), or `rejected` (and add a `reason`).
+
+No `/haytham:approve-criteria` command in v1. The editor is the UI. If we need a command later, we'll add it then.
+
+### 3. Update `/haytham:propose-next-steps`
+
+Two changes:
+
+- Read `telemetry.derived.yml` if it exists, falling back to `telemetry.yml` for capabilities that haven't been derived yet.
+- Filter to `status: approved` (and `status: modified`) entries only. Skip `pending` and `rejected`. If no approved entries exist for a capability, emit an `intent_gap` finding noting that derivation has not been approved yet.
+
+That's it. The proposer logic is otherwise unchanged.
+
+## Sequencing
+
+Four steps, roughly half a day each.
+
+1. **Write the derivation prompt.** Single LLM call. Inputs listed above. Output shape: same as current `telemetry.yml` plus `status` and `derived_from` per entry.
+2. **Run derivation on `gift-catalog`.** Compare the derived file against the existing hand-written `telemetry.yml` v3. Three buckets:
+   - **Derivation found something I missed.** Add to the case for derivation.
+   - **My hand-written version had something derivation can't justify.** Either I had hidden context not in the graph (then enrich the graph), or I was wrong (then drop the criterion).
+   - **Same in both.** Confirms the graph already encoded the intent; derivation is reproducing it correctly.
+3. **Add the `status` field and update the proposer** to read approved-only.
+4. **Re-run `/haytham:propose-next-steps`** with the derived-and-approved contract. Compare the proposals against the prior run. The question is whether the proposals are different (better, worse, or just different), not whether they're "right."
+
+## Definition of done
+
+- A derivation prompt that produces a candidate `telemetry.derived.yml` for `gift-catalog`.
+- Every derived criterion cites an upstream line.
+- The bucket comparison (derived vs hand-written) is written up — even one paragraph.
+- `propose-next-steps` filters by approval status.
+- The re-run produces a comparable proposals file.
+
+That's the v1. No new infrastructure beyond one prompt and one filter.
+
+## Honest test for whether the loop works
+
+If, after deriving and approving criteria for `gift-catalog`, at least one of these is true, the loop works:
+
+- A criterion in the hand-written v3 turns out not to be derivable from any upstream node, which means either the graph is under-specified or the criterion was aspirational.
+- Derivation surfaces a criterion I'd missed.
+- The re-run of `propose-next-steps` produces a proposal that the prior run did not.
+
+If none of those happen, derivation is just reformatting and the speculation about honesty was wrong. That's also a useful result — we'd know not to invest further.
+
+## Deferred (intentionally, not forgotten)
+
+The following were drafted in `2026-05-18-polymorphic-telemetry-contracts.md` and are **not in scope** for v1:
+
+- **Six measurement frameworks (polymorphism).** Hypothesis from walking through other GiftKaro capabilities; no actual failure yet from one schema. Revisit after a second capability is onboarded and the single schema visibly breaks.
+- **Error budgets and burn-state classification.** Amplification of a redesign we haven't built. Revisit if the approved-criteria proposals are still binary or shallow after the lean loop runs for a few weeks.
+- **Cross-platform vocabulary, `event-vocabulary.yml`, adapter dispatch.** No mobile project in scope. Revisit when one arrives.
+- **Approval state machine, audit history, multi-revision tracking.** YAML edits are enough for v1.
+- **`/haytham:derive-vocabulary`, `/haytham:approve-criteria`.** Commands we don't need yet.
+
+Each of these is a real future-want. None is justified by evidence right now.
+
+## Open questions for the lean v1
+
+1. Where does the property ID and baseline snapshot live in the derived file? Probably stays in the same place it does today, but worth confirming once we see what derivation actually emits.
+2. When a founder modifies a criterion (`status: modified`), should the derivation note that on the next re-run and preserve the modification, or should re-derivation start fresh? Lean answer: preserve modifications, surface diffs.
+3. Should `telemetry.derived.yml` replace `telemetry.yml` once approved, or coexist? Lean answer: coexist until we've seen one full loop, then decide.
+
+These don't need to be resolved before starting. They're the kind of questions whose answer becomes obvious once the first derivation runs.


### PR DESCRIPTION
## Summary

- New command `/haytham:derive-criteria <capability>` that derives a candidate `telemetry.derived.yml` from upstream graph nodes (shape) and calibrates numeric targets against observed GA4 baselines (numbers). Every entry is `status: pending` until the founder approves.
- `/haytham:propose-next-steps` updated to read `telemetry.derived.yml` when present and filter by `status: approved | modified`. Legacy `telemetry.yml` still supported for capabilities not yet migrated.
- Bumps plugin version to 0.3.22.

## Architecture

The honest split between work the system can do and work only the founder should do:

| Step | Done by |
|---|---|
| Derive criterion shape (definition, dimensions, events) | System (`derive-criteria`, from graph) |
| Calibrate criterion numbers (targets, thresholds, sample sizes) | System (`derive-criteria`, from observed baseline) |
| Decide whether a criterion survives | Founder (approve/modify/reject) |
| Override numbers with strategic intent | Founder |
| Add back items derivation couldn't justify | Founder |

The lean v1 plan is at `docs/plans/2026-05-22-derive-and-approve-criteria.md`. The earlier polymorphic-contracts exploration is preserved as deferred at `docs/plans/2026-05-18-polymorphic-telemetry-contracts.md`.

## Test plan

- [ ] Pull plugin update in a project with `./openspec/` populated
- [ ] Run `/haytham:derive-criteria <capability>` against an existing capability
- [ ] Verify output file is written at `./openspec/specs/<capability>/telemetry.derived.yml` with `status: pending` on every entry and `derived_from` citations
- [ ] Verify calibrated numbers when analytics MCP is available; verify TBD strings when it isn't
- [ ] Approve some entries (edit `status: pending` → `status: approved`), then run `/haytham:propose-next-steps`
- [ ] Confirm the proposer reads the derived file and skips unapproved entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)