### PR TITLE
fix: land the unpushed re-scope review fixes and harden the safety scripts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,11 +17,11 @@
       "license": "MIT",
       "keywords": [
         "startup",
-        "lifecycle",
+        "validation",
         "specification",
-        "control-plane",
+        "mvp",
         "agents",
-        "product"
+        "openspec"
       ],
       "category": "productivity"
     }

--- a/commands/haytham.md
+++ b/commands/haytham.md
@@ -616,7 +616,7 @@ Launch a **spec-generator** agent with this task:
 
 After the agent completes, run validation:
 ```bash
-python3 scripts/validate_openspec.py .haytham/session/phase-4-specs/openspec/ .haytham/session/phase-2-what/capabilities.json
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/validate_openspec.py" .haytham/session/phase-4-specs/openspec/ .haytham/session/phase-2-what/capabilities.json
 ```
 
 If validation produces warnings, report them to the user before the digest.
@@ -672,6 +672,3 @@ Command               Output Directory
 Tell the user:
 
 > Your specification is complete. Ran 9 agents across 4 phases. All output files are in `.haytham/session/`. Run `/haytham:build` to set up your project for implementation with OpenSpec.
->
-> **How did this go?** We're looking for honest feedback to make this better.
-> Share your experience: https://github.com/arslan70/haytham/discussions

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -51,7 +51,7 @@ Launch a **spec-generator** agent with this task:
 
 After the agent completes, run validation:
 ```bash
-python3 scripts/validate_openspec.py .haytham/session/phase-4-specs/openspec/ .haytham/session/phase-2-what/capabilities.json
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/validate_openspec.py" .haytham/session/phase-4-specs/openspec/ .haytham/session/phase-2-what/capabilities.json
 ```
 
 If validation produces warnings, report them to the user before the digest.

--- a/docs/blog/posts/2026-05-27-can-you-ask-claude-code-to-improve-your-system.md
+++ b/docs/blog/posts/2026-05-27-can-you-ask-claude-code-to-improve-your-system.md
@@ -16,6 +16,8 @@ description: "Five runs over ten days. The first found broken instrumentation. T
 
 # Can you ask Claude Code to improve your system?
 
+> **Status (2026-07-03): the commands this post describes were retired.** Haytham has since been re-scoped to a personal idea-to-MVP pipeline. `/haytham:propose-next-steps` and `/haytham:evolve` no longer exist in the plugin; their machinery is preserved at git tag [`v0.3.27-full`](https://github.com/arslan70/haytham/tree/v0.3.27-full). The post is kept as a record of what the loop found while it ran.
+
 Open Claude Code, Cursor, or whatever agent you use. Ask it: "Look at this project and suggest a meaningful improvement." Watch what comes back.
 
 <!-- more -->

--- a/docs/cofounder-brief.md
+++ b/docs/cofounder-brief.md
@@ -1,5 +1,7 @@
 # Haytham: A Technical Brief for Potential Collaborators
 
+> **Status (2026-07-03): retired.** Haytham was re-scoped to a personal idea-to-MVP tool and is not seeking collaborators. The control-plane vision described here is preserved at git tag `v0.3.27-full`. This page is kept as a record.
+
 ## The Vision
 
 Haytham is an autonomous control plane for startups. You describe an idea. It validates whether the idea is worth building, generates an implementation-ready specification, hands that spec to coding agents, deploys the result, monitors production, and continuously improves the system based on what it observes.

--- a/docs/design/haytham-evolve-v1.md
+++ b/docs/design/haytham-evolve-v1.md
@@ -1,7 +1,7 @@
 # `/haytham:evolve` v1 Design
 
 **Date:** 2026-04-19
-**Status:** Proposal. Aligns contracts before we write the command file.
+**Status:** Retired. `/haytham:evolve` shipped and closed the loop on GiftKaro, then was removed in the 2026-07-03 re-scope (v0.4.0). The command is preserved at git tag `v0.3.27-full`. This design is kept as a record.
 **Context:** Week 1 of the final push ([plan](../plans/2026-04-18-haytham-final-push.md)). The first real test is the GiftKaro bundle-categories change ([pre-registration](../experiments/week-2-gk-bundle-categories.md)); the bedrock test is the TinyTales cross-project run in Week 2.
 
 ## What v1 is

--- a/docs/gtm-strategy.md
+++ b/docs/gtm-strategy.md
@@ -1,5 +1,7 @@
 # Go-To-Market Strategy: 2-Week Sprint
 
+> **Status (2026-07-03): retired.** The sprint this strategy describes ended in April 2026, and Haytham has since been re-scoped to a personal tool with no go-to-market ambitions. This page is kept as a record.
+
 **Goal:** 5 people run `/haytham` on their own idea and give feedback.
 **Timeline:** March 19 - April 1, 2026
 **Kill condition:** Fewer than 5 runs by April 1 = project enters wind-down.

--- a/docs/haytham-cloud-operations-spec.md
+++ b/docs/haytham-cloud-operations-spec.md
@@ -1,5 +1,7 @@
 # Haytham Cloud Operations: Implementation Spec
 
+> **Status (2026-07-03): retired, never implemented.** This spec predates the re-scope to a personal idea-to-MVP tool; the `cloud-researcher` agent was never built. The page is kept as a record.
+
 ## Overview
 
 Add cloud enrichment to Haytham's Phase 3 (Technical Design). A new `cloud-researcher` agent runs after the `architect` agent, querying live provider data (pricing, features, limits) to ground build-buy decisions in reality rather than training knowledge.

--- a/docs/pivot-plan.md
+++ b/docs/pivot-plan.md
@@ -1,5 +1,7 @@
 # Plan: Hard Pivot to Claude Code Plugin
 
+> **Status (2026-07-03): completed.** The pivot this plan describes was carried out; this repo is now the plugin. The page is kept as a record.
+
 ## Context
 
 Haytham has two parallel systems: a standalone Python pipeline (200 files, 38K LOC) and a Claude Code plugin (18 files, 2.4K LOC). The plugin is the product. The standalone system is dead weight. The user wants fast feedback, which means a clean repo that IS a plugin.

--- a/docs/plans/2026-05-18-polymorphic-telemetry-contracts.md
+++ b/docs/plans/2026-05-18-polymorphic-telemetry-contracts.md
@@ -19,7 +19,7 @@ Without this, the SENTIENCE loop is mostly synthetic: the proposer "discovers" g
 
 Three things converged that exposed the current design's limits.
 
-**One.** The first end-to-end loop run (2026-05-17) demonstrated the engineering closes, but on audit, every "finding" the system surfaced was something the founder had hand-annotated into `telemetry.yml` a day earlier. The proposer relayed; it didn't reason. See [docs/blog/posts/2026-05-18-can-you-ask-claude-code-to-improve-your-system.md](../blog/posts/2026-05-18-can-you-ask-claude-code-to-improve-your-system.md) for the public version; the cheating audit was sharper than the blog admits.
+**One.** The first end-to-end loop run (2026-05-17) demonstrated the engineering closes, but on audit, every "finding" the system surfaced was something the founder had hand-annotated into `telemetry.yml` a day earlier. The proposer relayed; it didn't reason. See [docs/blog/posts/2026-05-27-can-you-ask-claude-code-to-improve-your-system.md](../blog/posts/2026-05-27-can-you-ask-claude-code-to-improve-your-system.md) for the public version; the cheating audit was sharper than the blog admits.
 
 **Two.** A polished sentence in that blog post ("the success threshold my contract used to judge this capability depended on a measurement that wasn't actually being captured, so the system couldn't tell whether the capability was working") triggered the right question: *which agent actually did that work?* Answer: none. The contract author did. The system surfaced an annotation.
 

--- a/scripts/check_phase_prereqs.sh
+++ b/scripts/check_phase_prereqs.sh
@@ -27,6 +27,10 @@ if [ -z "$AGENT_TYPE_LOWER" ]; then
     exit 0
 fi
 
+# Gate files live under the project root's .haytham/, never the hook CWD —
+# the hook may run from a directory that has an unrelated .haytham/.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+
 # Map agent names to required prerequisite files
 check_prereq() {
     local prereq_file="$1"
@@ -42,17 +46,17 @@ check_prereq() {
 
 # Phase 2 agents require Phase 1 gate decision
 if echo "$AGENT_TYPE_LOWER" | grep -qE '(mvp-scoper|capability-modeler)'; then
-    check_prereq ".haytham/session/phase-1-why/gate-decision.json" "Phase 1 (WHY)"
+    check_prereq "$PROJECT_DIR/.haytham/session/phase-1-why/gate-decision.json" "Phase 1 (WHY)"
 fi
 
 # Phase 3 agents require Phase 2 gate decision
 if echo "$AGENT_TYPE_LOWER" | grep -qE '(architect)'; then
-    check_prereq ".haytham/session/phase-2-what/gate-decision.json" "Phase 2 (WHAT)"
+    check_prereq "$PROJECT_DIR/.haytham/session/phase-2-what/gate-decision.json" "Phase 2 (WHAT)"
 fi
 
 # Phase 4 agents require Phase 3 gate decision
 if echo "$AGENT_TYPE_LOWER" | grep -qE '(spec-generator)'; then
-    check_prereq ".haytham/session/phase-3-how/gate-decision.json" "Phase 3 (HOW)"
+    check_prereq "$PROJECT_DIR/.haytham/session/phase-3-how/gate-decision.json" "Phase 3 (HOW)"
 fi
 
 # All checks passed

--- a/scripts/validate_som.py
+++ b/scripts/validate_som.py
@@ -107,6 +107,30 @@ def validate_som_arithmetic(report_text: str) -> list[str]:
     return []
 
 
+def _extract_idea_without_yaml(raw: str) -> str:
+    """Best-effort idea extraction when pyyaml is unavailable.
+
+    Handles both the inline form (`idea: some text`) and the block-scalar
+    form (`idea: |`) that project.yaml actually uses. Only the idea value is
+    returned — never the whole file, whose founder_context and other prose
+    sections would trigger false regulated-domain warnings.
+    """
+    match = re.search(r"^idea:[ \t]*(.*)$", raw, re.MULTILINE)
+    if not match:
+        return ""
+    inline = match.group(1).strip()
+    if not inline.startswith(("|", ">")):
+        return inline.strip("\"'")
+    # Block scalar: collect the indented lines that follow, stopping at the
+    # next top-level (unindented) key.
+    block = []
+    for line in raw[match.end() :].splitlines():
+        if line.strip() and not line[:1].isspace():
+            break
+        block.append(line.strip())
+    return " ".join(part for part in block if part)
+
+
 def validate_regulated_domain_safety(
     report_text: str, idea_text: str, recommendation: str
 ) -> list[str]:
@@ -193,12 +217,7 @@ def main():
                 if isinstance(project, dict):
                     idea_text = str(project.get("idea") or "")
             except ImportError:
-                # Without yaml, extract only the idea value. Never feed the
-                # whole file to the domain regexes: founder_context and other
-                # prose sections would trigger false compliance warnings.
-                match = re.search(r"^idea:[ \t]*(.+)$", raw, re.MULTILINE)
-                if match:
-                    idea_text = match.group(1).strip().strip("\"'")
+                idea_text = _extract_idea_without_yaml(raw)
             except Exception:
                 pass
 

--- a/scripts/validate_som.py
+++ b/scripts/validate_som.py
@@ -181,17 +181,25 @@ def main():
         haytham_root = os.sep.join(parts[: parts.index(".haytham") + 1])
         project_yaml = os.path.join(haytham_root, "project.yaml")
         try:
-            import yaml
-
             with open(project_yaml) as f:
-                project = yaml.safe_load(f)
-                idea_text = project.get("idea", "")
-        except Exception:
-            # If yaml isn't available or file doesn't exist, try plain read
+                raw = f.read()
+        except OSError:
+            raw = ""
+        if raw:
             try:
-                with open(project_yaml) as f:
-                    idea_text = f.read()
-            except (FileNotFoundError, OSError):
+                import yaml
+
+                project = yaml.safe_load(raw)
+                if isinstance(project, dict):
+                    idea_text = str(project.get("idea") or "")
+            except ImportError:
+                # Without yaml, extract only the idea value. Never feed the
+                # whole file to the domain regexes: founder_context and other
+                # prose sections would trigger false compliance warnings.
+                match = re.search(r"^idea:[ \t]*(.+)$", raw, re.MULTILINE)
+                if match:
+                    idea_text = match.group(1).strip().strip("\"'")
+            except Exception:
                 pass
 
     warnings.extend(

--- a/scripts/validate_som.py
+++ b/scripts/validate_som.py
@@ -171,28 +171,28 @@ def main():
     warnings = validate_som_arithmetic(report_text)
 
     # Try to read the idea from project.yaml for regulated domain checks.
-    # Resolve it from the report's own .haytham root, not the CWD — the
+    # Resolve it from the report's own .haytham root, never the CWD — the
     # process may run from a directory that has an unrelated .haytham/.
+    # If the report is not under a .haytham tree, the idea is unknown and
+    # the domain checks are skipped rather than run against a guess.
     idea_text = ""
     parts = os.path.abspath(file_path).split(os.sep)
     if ".haytham" in parts:
         haytham_root = os.sep.join(parts[: parts.index(".haytham") + 1])
         project_yaml = os.path.join(haytham_root, "project.yaml")
-    else:
-        project_yaml = os.path.join(".haytham", "project.yaml")
-    try:
-        import yaml
-
-        with open(project_yaml) as f:
-            project = yaml.safe_load(f)
-            idea_text = project.get("idea", "")
-    except Exception:
-        # If yaml isn't available or file doesn't exist, try plain read
         try:
+            import yaml
+
             with open(project_yaml) as f:
-                idea_text = f.read()
-        except (FileNotFoundError, OSError):
-            pass
+                project = yaml.safe_load(f)
+                idea_text = project.get("idea", "")
+        except Exception:
+            # If yaml isn't available or file doesn't exist, try plain read
+            try:
+                with open(project_yaml) as f:
+                    idea_text = f.read()
+            except (FileNotFoundError, OSError):
+                pass
 
     warnings.extend(
         validate_regulated_domain_safety(report_text, idea_text, recommendation)


### PR DESCRIPTION
## What this is

Two commits that were meant for #69 but landed after it merged.

**29dcbca** sat unpushed on the local branch when #69 was merged, so its fixes never reached main: `${CLAUDE_PLUGIN_ROOT}` resolution for validate_openspec.py in the plan/haytham commands, the validate_som.py CWD-fallback removal, retirement banners on the archived docs pages, the blog post rename to match its frontmatter date, the Discussions-funnel removal, and the marketplace keyword refresh.

**8d3e994** addresses findings 1-3 from the post-merge review of #69, all in the deterministic safety layer:

- `check_phase_prereqs.sh` resolved gate-decision.json relative to the hook process CWD, so a stale or unrelated `.haytham/` in the CWD could satisfy a phase gate, and a session that had cd'd into a subdirectory could be wrongly blocked. The gate paths now anchor on `CLAUDE_PROJECT_DIR`, falling back to `PWD` when unset.
- `validate_som.py` crashed with a TypeError on an explicit null `idea:` key (`dict.get`'s default doesn't cover null), violating its exit-0 non-blocking contract and surfacing a raw traceback through the PostToolUse hook.
- The no-pyyaml fallback fed the entire raw project.yaml (founder_context included) to the regulated-domain regexes, producing false PCI-DSS/HIPAA warnings on machines without pyyaml, which is the common hook environment. The fallback now extracts only the `idea:` line.

## Verification

- Sanity suite after rebasing onto main: 168 passed, 5 skipped
- All three script fixes reproduced end-to-end before and after: null-idea crash (exit 1 traceback → exit 0), false PCI-DSS warning from founder prose under yaml-less python3 (fires → silent, while a genuinely fintech idea still warns), and the hook gate false-pass/false-block scenarios under stale-CWD and subdirectory CWDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)