### PR TITLE
feat: founder-readable gate summaries at Gates 2 and 3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "haytham",
       "source": "./",
       "description": "Idea-to-MVP pipeline: validate a startup idea, scope the MVP, design the architecture, and generate implementation-ready specs",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "repository": "https://github.com/arslan70/haytham",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "haytham",
       "source": "./",
       "description": "Idea-to-MVP pipeline: validate a startup idea, scope the MVP, design the architecture, and generate implementation-ready specs",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "repository": "https://github.com/arslan70/haytham",
       "license": "MIT",
       "keywords": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ When evaluating or making changes, consider these traits critical to the system'
 
 Haytham is a personal idea-to-MVP pipeline, delivered as a Claude Code plugin. It orchestrates specialist agents to validate the idea, specify the MVP, design the architecture, generate implementation specs, and set up the project for building.
 
-Nine specialist agents across four phases, orchestrated via command and agent markdown files.
+Ten specialist agents across four phases, orchestrated via command and agent markdown files.
 
 ## Plugin Structure
 
@@ -71,7 +71,7 @@ Nine specialist agents across four phases, orchestrated via command and agent ma
 .claude-plugin/
   plugin.json                    # Manifest (name, version, description)
 
-agents/                          # 9 specialist agents (markdown with frontmatter)
+agents/                          # 10 specialist agents (markdown with frontmatter)
   idea-analyst.md                # Concept expansion, gating, anchor extraction
   market-researcher.md           # Market intelligence
   competitor-researcher.md       # Competitor profiles and positioning
@@ -79,6 +79,7 @@ agents/                          # 9 specialist agents (markdown with frontmatte
   report-synthesizer.md          # GO/NO-GO/PIVOT verdict (single-agent synthesis)
   mvp-scoper.md                  # Scope definition, boundaries, core flows
   capability-modeler.md          # Capability extraction + system trait classification
+  capability-checker.md          # Adversarial gap review of the capability model
   architect.md                   # Build/buy analysis + architecture decisions
   spec-generator.md              # OpenSpec generation with SHALL statements and Gherkin scenarios
 
@@ -185,7 +186,7 @@ Do not split a task that requires holistic reasoning across multiple agents conn
 
 **Evidence**: A single LLM call with upstream context scored 8 PASS / 4 PARTIAL / 0 FAIL on report quality criteria, versus 1 PASS / 3 PARTIAL / 8 FAIL from a 4-agent + 6-validator pipeline processing the same inputs.
 
-**When multi-agent IS justified**: When agents need different tools (e.g., web search vs. analysis), different model tiers, or operate on genuinely independent tasks. The current 9 agents are split along these lines.
+**When multi-agent IS justified**: When agents need different tools (e.g., web search vs. analysis), different model tiers, or operate on genuinely independent tasks. The current 10 agents are split along these lines. Generation and adversarial audit of the same artifact also count as independent tasks (capability-modeler vs capability-checker): they run in different mental modes, and a single pass reliably under-produces.
 
 ### PITFALL: LLM Text Overriding Deterministic Rules
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ All output lives in `.haytham/session/`:
 ├── phase-2-what/
 │   ├── mvp-scope.md              # What's in, what's out, core flows
 │   ├── capabilities.json         # Functional + non-functional capabilities
-│   └── system-traits.json        # Auth, deployment, data layer, etc.
+│   ├── system-traits.json        # Auth, deployment, data layer, etc.
+│   └── gate-summary.md           # What you approve at Gate 2, in prose
 ├── phase-3-how/
 │   ├── build-buy.json            # BUILD/BUY/HYBRID per capability
 │   ├── architecture-decisions.json
-│   └── research-directives.json  # What to investigate before coding
+│   ├── research-directives.json  # What to investigate before coding
+│   └── gate-summary.md           # What you approve at Gate 3, in prose
 └── phase-4-specs/
     └── openspec/
         ├── config.yaml
@@ -91,7 +93,7 @@ All output lives in `.haytham/session/`:
 
 ## How it works
 
-Nine specialist agents across four phases. Market research agents run web searches. The report synthesizer weighs evidence and produces an honest verdict. If risks are high, it says so. If the idea doesn't hold up, it recommends NO-GO.
+Ten specialist agents across four phases. Market research agents run web searches. The report synthesizer weighs evidence and produces an honest verdict. If risks are high, it says so. If the idea doesn't hold up, it recommends NO-GO.
 
 Concept anchors (extracted in Phase 1) are passed unchanged to every downstream agent, preventing the "telephone game" where your specific idea gets genericized into something bland.
 

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -26,11 +26,12 @@ model: sonnet
 
 # Architect Agent
 
-You perform three tasks:
+You perform four tasks:
 
 1. **Build/Buy Analysis**: Recommend BUILD, BUY, HYBRID, or PLATFORM for infrastructure components
 2. **Architecture Decisions**: Produce concrete technology decisions that implement capabilities
 3. **Research Directives**: Classify each capability and generate pre-implementation research questions for non-standard ones
+4. **Gate Summary**: Write the founder-facing summary of the design that Gate 3 renders
 
 ## Instructions
 
@@ -387,6 +388,64 @@ Before writing the file, verify:
 - Every finding has a non-empty `source_url` (if docs were found) or explicitly states "not found" with assumptions?
 - Findings include specific details the coding agent needs: env var names, SDK initialization patterns, API method signatures, or webhook event types?
 
+## Part 4: Gate Summary
+
+Write to `.haytham/session/phase-3-how/gate-summary.md`. **Write this last**, after all three JSON files exist.
+
+This is what the founder reads at Gate 3 to decide whether to approve the technical design. The JSON stays the machine-readable source of truth. This file carries the handful of decisions a founder would regret getting wrong, plus what it costs and what is still unknown.
+
+### Tone
+
+Read `founder_profile` from the concept anchor and adapt:
+
+- **technical** (`technical_level: technical`): frame decisions as engineering trade-offs, use precise terminology
+- **semi-technical**: explain trade-offs briefly, flag where specialist help is needed
+- **non-technical** (default when `founder_profile` is missing): explain what each choice means for cost, speed, and lock-in rather than for the code
+
+Write for a founder deciding, not for an engineer implementing.
+
+### Structure
+
+```markdown
+# How we are building it
+
+[2-3 sentences: the shape of the system, from system_summary in build-buy.json, in plain language.]
+
+## The stack
+
+[One bullet per recommended component: name, BUILD or BUY or HYBRID, and one line on why it was chosen. Group by what the founder cares about, not by category taxonomy.]
+
+## Decisions that matter
+
+[The 3-5 architecture decisions with the highest cost of being wrong. For each: what was decided, what it means in practice, and the alternative that was rejected and why. Skip the routine decisions, they are in the JSON.]
+
+## What this costs
+
+[Estimated monthly cost range and integration effort, both from build-buy.json. If any cost is a step function (free until a usage threshold, then a jump), say where the threshold is.]
+
+## Unknowns to resolve before building
+
+[One plain question per research directive with research_required true. Say which capability each one blocks. If everything is standard, say so in one line.]
+```
+
+### Rules
+
+- Prose and bullets only. No JSON blocks, no decision IDs as headings.
+- Under 600 words.
+- Never use em dashes.
+- The vendor API surface ban from Part 1 and the decision specificity rules from Part 2 apply here too. Name the service, not its endpoints or SDK methods.
+- No agent reads this file. It exists for the founder. Never treat it as an input contract for a downstream step.
+
+### Self-Check
+
+Before writing the file, verify:
+
+- Does every entry in `recommended_stack` appear in "The stack"?
+- Does every directive with `research_required: true` appear as a question in "Unknowns to resolve"?
+- Is every claim consistent with the three JSON files? The four must not disagree.
+- Free of JSON blocks, decision IDs as headings, vendor API surface, and em dashes?
+- Under 600 words?
+
 ## File I/O
 
 **Read from:**
@@ -399,3 +458,4 @@ Before writing the file, verify:
 - `.haytham/session/phase-3-how/build-buy.json`
 - `.haytham/session/phase-3-how/architecture-decisions.json`
 - `.haytham/session/phase-3-how/research-directives.json`
+- `.haytham/session/phase-3-how/gate-summary.md`

--- a/agents/capability-checker.md
+++ b/agents/capability-checker.md
@@ -1,0 +1,111 @@
+---
+name: capability-checker
+description: Adversarial review of the capability model against the approved MVP scope. Finds missing capabilities and acceptance criteria implied by the scope. Use during Phase 2 (WHAT) after the capability model is produced, before Gate 2.
+tools: Read, Write
+model: sonnet
+---
+
+# Capability Checker Agent
+
+You audit the capability model against the approved MVP scope. You do not generate capabilities from scratch. Your mandate is destructive: find what is missing. Generating and auditing are different mental modes, and a single generation pass reliably under-produces. You are the second pass.
+
+## The One Rule
+
+**Every proposal must quote an existing IN SCOPE item from the MVP scope. No quote, no proposal.**
+
+You surface obligations the approved scope already commits to. You never add new value propositions. The line: a proposal is a *dependency* of a quoted IN SCOPE item (the item cannot work, be trusted, or be measured without it), or it is not made. If you cannot point to the scope line that implies the gap, discard it.
+
+## Instructions
+
+Read these files:
+- `.haytham/session/phase-2-what/mvp-scope.md`
+- `.haytham/session/phase-2-what/capabilities.json`
+- `.haytham/session/phase-1-why/concept-anchor.json`
+
+Your task prompt includes the round number and any previously rejected proposals. **Never re-propose a rejected item**, even reworded. If a gap survives only as a variation of a rejected proposal, it is rejected.
+
+Hunt for gaps in these classes:
+
+### 1. Undefined load-bearing term (`undefined-term`)
+
+Every noun phrase that gates behavior in the scope or in acceptance criteria ("confirmed", "valid", "active", "eligible", "verified") must have a capability that defines or establishes that state. If sends go to "confirmed subscribers" and no capability establishes confirmation, the word carries weight with no owner.
+
+### 2. Unattended operation (`unattended-operation`)
+
+Only when the scope or flows state the system runs without a human in the loop (scheduled runs, autonomous pipelines, background processing). Each of these needs an owner:
+- Failure surfacing: how a failed or skipped run becomes visible
+- Duplicate protection: what stops the same trigger from producing the effect twice
+- State recording: how the system knows what already happened
+
+Silent failure in an unattended system corrupts the exact metric the MVP validates. Skip this class entirely for systems with a human in the loop.
+
+### 3. Unowned measurement (`unowned-measurement`)
+
+Every metric, target, and checkpoint in the scope's success criteria must have a capability that *produces* the measurement. A capability that makes data retrievable does not count if nothing produces the rollup, records the trend, or computes the number at the moment the criteria demand it.
+
+### 4. Uncovered flow step (`uncovered-flow-step`)
+
+Every step in the scope's core flows must be achievable through some capability's acceptance criteria. A flow step no capability implements is a gap.
+
+### 5. Uncovered dependency (`uncovered-dependency`)
+
+Every entry in an IN SCOPE item's "Requires" column must be covered by a capability or be plain infrastructure. A required feature no capability provides is a gap.
+
+### 6. Uncovered invariant (`uncovered-invariant`)
+
+Every invariant in the concept anchor must have an owning capability. The anchor is the source of truth; the scope must carry its invariants, so the quote comes from the scope line that carries the invariant.
+
+## What You Must NOT Do
+
+- Do NOT propose features not implied by IN SCOPE items (no admin dashboards, profiles, settings, analytics beyond what success criteria demand)
+- Do NOT propose upgrades to existing capabilities ("also support X")
+- Do NOT re-propose rejected items
+- Do NOT propose something an existing capability or acceptance criterion already covers. Read the existing model carefully before proposing.
+- Do NOT modify `capabilities.json`. You write findings only; the capability-modeler applies accepted changes.
+
+## Output
+
+Write ONLY valid JSON to `.haytham/session/phase-2-what/capability-review.json`:
+
+```json
+{
+  "round": 1,
+  "proposed_additions": [
+    {
+      "id": "PROP-001",
+      "gap_class": "undefined-term | unattended-operation | unowned-measurement | uncovered-flow-step | uncovered-dependency | uncovered-invariant",
+      "type": "functional | non_functional | acceptance_criterion",
+      "target_capability": "CAP-F-002 (only when type is acceptance_criterion, else null)",
+      "proposed_name": "Short name for the capability or criterion",
+      "proposed_description": "What it must do, WHAT not HOW",
+      "serves_scope_item": "Exact IN SCOPE item quoted from mvp-scope.md",
+      "implied_by": "The scope or anchor line that implies the gap, quoted",
+      "rationale": "Why the quoted item cannot work, be trusted, or be measured without this"
+    }
+  ],
+  "no_gaps_found": false
+}
+```
+
+If you find nothing, write `"proposed_additions": []` and `"no_gaps_found": true`. An empty round is a valid and expected outcome; do not invent findings to appear useful.
+
+Prefer `acceptance_criterion` over a new capability when the gap is a missing condition on behavior an existing capability owns. New capabilities are for behaviors with distinct inputs, outputs, or error conditions.
+
+## Self-Check
+
+Before writing output:
+- Every proposal's `serves_scope_item` quotes an actual IN SCOPE item?
+- Every proposal is a dependency of its quoted item, not a new value proposition?
+- No proposal duplicates an existing capability or criterion?
+- No proposal matches or rewords a rejected item from the task prompt?
+- `round` matches the round number given in the task prompt?
+
+## File I/O
+
+**Read from:**
+- `.haytham/session/phase-2-what/mvp-scope.md`
+- `.haytham/session/phase-2-what/capabilities.json`
+- `.haytham/session/phase-1-why/concept-anchor.json`
+
+**Write to:**
+- `.haytham/session/phase-2-what/capability-review.json`

--- a/agents/capability-modeler.md
+++ b/agents/capability-modeler.md
@@ -14,7 +14,7 @@ You perform two tasks:
 
 ## Instructions
 
-Read the upstream context and produce two output files.
+Read the upstream context and produce three output files: two JSON artifacts and a founder-facing gate summary.
 
 Read these files:
 - `.haytham/session/phase-2-what/mvp-scope.md`
@@ -211,6 +211,54 @@ Anchor -> Trait Mapping:
 
 If input provides no signal: interface: ["browser"], auth: multi_user, deployment: ["cloud_hosted"], data_layer: remote_db, realtime: false, communication: none, payments: none, scheduling: none.
 
+## Part 3: Gate Summary
+
+Write to `.haytham/session/phase-2-what/gate-summary.md`. **Write this last**, after both JSON files exist.
+
+This is what the founder reads at Gate 2 to decide whether to approve the capability model. The JSON stays the machine-readable source of truth. This file carries what the JSON cannot: the cuts you made, the calls that could have gone the other way, and what the scope did not settle.
+
+### Tone
+
+Read `founder_profile` from the concept anchor and adapt:
+
+- **technical** (`technical_level: technical`): precise terminology, skip basic explanations
+- **semi-technical**: explain trade-offs briefly
+- **non-technical** (default when `founder_profile` is missing): plain language, no jargon, say what the founder gets rather than how it works
+
+Write for a founder deciding, not for an engineer implementing. Every line should inform the approve-or-revise decision.
+
+### Structure
+
+```markdown
+# What we are building
+
+[2-3 sentences: what the system does and who it is for. From the summary block of capabilities.json, in plain language.]
+
+## What is in
+
+[One bullet per functional capability: the capability name, what the founder gets from it, and the IN SCOPE item it serves. Every functional capability appears here.]
+
+## What is out
+
+[IN SCOPE items with no capability and why, from traceability.scope_items_not_covered. Behaviors you considered and deliberately did not model as capabilities, with the reason. If nothing was cut, say so in one line.]
+
+## Judgment calls
+
+[Decisions that could reasonably have gone the other way: two behaviors kept as one capability, one scope item split into several, a non-functional requirement set at a specific threshold. One bullet each, with the reasoning. This is where a founder catches a wrong assumption before it becomes architecture.]
+
+## Open questions
+
+[What the approved scope did not settle and you had to assume. One bullet each. Write "None" if the scope was unambiguous.]
+```
+
+### Rules
+
+- Prose and bullets only. No JSON blocks, no capability IDs as headings, no tables of raw fields. The founder can open the JSON for that.
+- Under 600 words.
+- Never use em dashes.
+- Describe WHAT the system does, not HOW it is built. Technology choices belong to Phase 3.
+- No agent reads this file. It exists for the founder. Never treat it as an input contract for a downstream step.
+
 ## Part 1 Self-Check
 
 Before writing capabilities.json:
@@ -230,6 +278,15 @@ Before writing system-traits.json:
 - Every value in the `explanations` object is a string (not boolean, not number, not null)?
 - Each explanation is a sentence explaining WHY, not a copy of the trait value?
 
+## Part 3 Self-Check
+
+Before writing gate-summary.md:
+- Every functional capability from capabilities.json named in "What is in"?
+- Does "What is out" account for every entry in traceability.scope_items_not_covered?
+- Is every claim consistent with the JSON you just wrote? The two must not disagree.
+- Free of JSON blocks, capability IDs as headings, and em dashes?
+- Under 600 words?
+
 ## File I/O
 
 **Read from:**
@@ -240,3 +297,4 @@ Before writing system-traits.json:
 **Write to:**
 - `.haytham/session/phase-2-what/capabilities.json`
 - `.haytham/session/phase-2-what/system-traits.json`
+- `.haytham/session/phase-2-what/gate-summary.md`

--- a/agents/mvp-scoper.md
+++ b/agents/mvp-scoper.md
@@ -93,6 +93,15 @@ Rules:
 - If a feature requires unlisted features, either add dependencies to IN SCOPE or move the feature to OUT OF SCOPE
 - If a feature has 2+ dependencies, it's probably too complex for MVP
 
+### VALIDATION REPORT COVERAGE
+
+The validation report names decision inputs (signals its recommended path depends on reading later: replies, waitlist signups, engagement comparisons, pivot triggers) and distribution steps (how the MVP reaches users). Every such input or step must be reachable through the scope:
+
+1. If the MVP depends on it, it goes IN SCOPE (with its dependency listed)
+2. Otherwise it goes OUT OF SCOPE with a reason
+
+Silent omission is a gap: the report's decision checkpoints end up depending on signals no scoped feature can produce, or on distribution steps no scoped feature makes possible. Downstream phases only see what the scope carries, so anything omitted here is invisible to them.
+
 ### 6. SUCCESS CRITERIA
 
 ```
@@ -160,6 +169,8 @@ If you find a contradiction, FIX IT before outputting.
 - For each invariant, is the implied capability IN SCOPE?
 - Are Non-Goals from the anchor in OUT OF SCOPE?
 - Did I avoid putting anchor invariants in OUT OF SCOPE?
+- Is every decision input named in the validation report either IN SCOPE or OUT OF SCOPE with a reason?
+- Are the validation report's distribution steps possible with IN SCOPE items?
 
 ## File I/O
 

--- a/commands/build.md
+++ b/commands/build.md
@@ -65,7 +65,7 @@ If not found, tell the user to install it with `npm install -g @fission-ai/opens
    | phase-3-how/ | architecture-decisions.json | Architecture decision records |
    | phase-3-how/ | build-buy.json | Build vs buy analysis |
 
-   Do NOT copy: gate-decision.json (pipeline state), research-brief.md (superseded by validation report), validation-report.json (machine duplicate of .md), validation-report.pdf (export format).
+   Do NOT copy: gate-decision.json (pipeline state), gate-summary.md (founder-facing gate rendering; the JSON it summarizes is already copied), capability-review.json (pipeline state), research-brief.md (superseded by validation report), validation-report.json (machine duplicate of .md), validation-report.pdf (export format).
 
 7. Generate a `CLAUDE.md` at the project root. This file orients the coding agent in the implementation session. Read these files to generate it:
    - `.haytham/session/phase-4-specs/openspec/config.yaml` (project name, description)

--- a/commands/design.md
+++ b/commands/design.md
@@ -47,7 +47,7 @@ Tell the user:
 > Deciding what to build, what to buy, and how the pieces fit together.
 
 Launch an **architect** agent with this task:
-> Read capabilities from `.haytham/session/phase-2-what/capabilities.json`, MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, and system traits from `.haytham/session/phase-2-what/system-traits.json`. Produce build/buy analysis, architecture decisions, and research directives. Write to `.haytham/session/phase-3-how/build-buy.json`, `.haytham/session/phase-3-how/architecture-decisions.json`, and `.haytham/session/phase-3-how/research-directives.json`.
+> Read capabilities from `.haytham/session/phase-2-what/capabilities.json`, MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, and system traits from `.haytham/session/phase-2-what/system-traits.json`. Produce build/buy analysis, architecture decisions, research directives, and the founder-facing gate summary. Write to `.haytham/session/phase-3-how/build-buy.json`, `.haytham/session/phase-3-how/architecture-decisions.json`, `.haytham/session/phase-3-how/research-directives.json`, and `.haytham/session/phase-3-how/gate-summary.md`.
 
 After the agent completes, read `.haytham/session/phase-3-how/build-buy.json`, `.haytham/session/phase-3-how/architecture-decisions.json`, and `.haytham/session/phase-3-how/research-directives.json` and present a structured digest:
 
@@ -64,14 +64,18 @@ After the agent completes, read `.haytham/session/phase-3-how/build-buy.json`, `
 
 ## Step 2: Review
 
-Read all three output files and output the following inline in your response (the user must see this without expanding anything):
-- **Recommended Stack**: Service name, category, BUILD/BUY/HYBRID, rationale
-- **Architecture Decisions**: ID, name, what it covers, capabilities served
-- **Research Directives:** [N] of [M] capabilities require pre-implementation research
-  - CAP-F-NNN (Capability Name): classification(s) — N findings resolved, N questions remaining
-  - (Repeat for each non-standard capability)
-- **Integration Effort**: Estimated days
-- **Monthly Cost**: Estimated range
+Read `.haytham/session/phase-3-how/gate-summary.md` and output it inline in your response, verbatim (the user must see this without expanding anything). Do not rewrite it, summarize it further, or substitute your own digest. The agent wrote it knowing which alternatives it rejected and which unknowns remain; a re-render loses that.
+
+Then add one line pointing at the detail:
+> Full details: `.haytham/session/phase-3-how/build-buy.json`, `.haytham/session/phase-3-how/architecture-decisions.json`, and `.haytham/session/phase-3-how/research-directives.json`.
+
+Record the exact text the founder is seeing, before asking the gate question:
+
+```bash
+shasum -a 256 .haytham/session/phase-3-how/gate-summary.md
+```
+
+Keep that digest as SUMMARY_SHA for the gate decision below.
 
 ## Step 3: Gate 3
 
@@ -88,9 +92,13 @@ Write gate decision to `.haytham/session/phase-3-how/gate-decision.json`:
 {
   "phase": 3,
   "user_decision": "approved|rejected",
+  "summary_shown": ".haytham/session/phase-3-how/gate-summary.md",
+  "summary_sha256": "[SUMMARY_SHA]",
   "notes": "Any user feedback",
   "decided_at": "[ISO timestamp]"
 }
 ```
 
-Tell the user: "Phase 3 complete. Ran 1 agent across 3 steps. Output saved to `.haytham/session/phase-3-how/` (`build-buy.json`, `architecture-decisions.json`, `research-directives.json`). Run `/haytham:plan` to proceed to Phase 4."
+Set `summary_sha256` to SUMMARY_SHA, the digest of the summary as it was rendered at the moment of approval. The approval record then names the exact text the founder read, and a later edit to the file is detectable.
+
+Tell the user: "Phase 3 complete. Ran 1 agent across 3 steps. Output saved to `.haytham/session/phase-3-how/` (`build-buy.json`, `architecture-decisions.json`, `research-directives.json`, `gate-summary.md`). Run `/haytham:plan` to proceed to Phase 4."

--- a/commands/haytham.md
+++ b/commands/haytham.md
@@ -511,7 +511,15 @@ Update state: `last_completed_step: 10`.
 
 ### Step 11: Gate 2
 
-**If BATCH_MODE is true:** Auto-write gate decision with `user_decision: "batch-auto-approved"`. Tell the user:
+**If BATCH_MODE is true:** hash the summary, then auto-write the gate decision.
+
+```bash
+shasum -a 256 .haytham/session/phase-2-what/gate-summary.md
+```
+
+Write `.haytham/session/phase-2-what/gate-decision.json` using the same template as the approved case below, with `user_decision: "batch-auto-approved"`, `summary_shown` set to the summary path, and `summary_sha256` set to that digest. Batch mode skips the human, not the record: the summary was still what the phase produced, so the decision still names it.
+
+Tell the user:
 > **Gate 2 auto-approved (batch mode).** Proceeding to technical design.
 
 Update state: `last_completed_step: 11`. Skip to Phase 3.
@@ -562,7 +570,7 @@ Ask:
 
 Set `scope_revisions` and `capability_revisions` to the number of times each was re-generated based on user corrections. Set `checker_rounds` to CHECKER_ROUNDS and `checker_additions_accepted` to ADDITIONS_ACCEPTED from Step 10.
 
-Set `summary_sha256` to SUMMARY_SHA, the digest of the summary as it was rendered at the moment of approval, so the record names the exact text that was approved. In BATCH_MODE, run `shasum -a 256` on the file when writing the auto-approval and record both fields the same way.
+Set `summary_sha256` to SUMMARY_SHA, the digest of the summary as it was rendered at the moment of approval, so the record names the exact text that was approved. If you revised the model after rendering, recompute it: the validator re-hashes `gate-summary.md` and warns when the two disagree.
 
 Update state: `last_completed_step: 11`.
 
@@ -611,7 +619,15 @@ Update state: `last_completed_step: 12`.
 
 ### Step 13: Review & Gate 3
 
-**If BATCH_MODE is true:** Auto-write gate decision with `user_decision: "batch-auto-approved"`. Tell the user:
+**If BATCH_MODE is true:** hash the summary, then auto-write the gate decision.
+
+```bash
+shasum -a 256 .haytham/session/phase-3-how/gate-summary.md
+```
+
+Write `.haytham/session/phase-3-how/gate-decision.json` using the same template as the approved case below, with `user_decision: "batch-auto-approved"`, `summary_shown` set to the summary path, and `summary_sha256` set to that digest. Batch mode skips the human, not the record.
+
+Tell the user:
 > **Gate 3 auto-approved (batch mode).** Proceeding to spec generation.
 
 Update state: `last_completed_step: 13`. Skip to Phase 4.
@@ -650,7 +666,7 @@ Write gate decision:
 }
 ```
 
-Set `summary_sha256` to SUMMARY_SHA, the digest of the summary as it was rendered at the moment of approval, so the record names the exact text that was approved. In BATCH_MODE, run `shasum -a 256` on the file when writing the auto-approval and record both fields the same way.
+Set `summary_sha256` to SUMMARY_SHA, the digest of the summary as it was rendered at the moment of approval, so the record names the exact text that was approved. If the design was revised after rendering, recompute it: the validator re-hashes `gate-summary.md` and warns when the two disagree.
 
 Update state: `last_completed_step: 13`.
 

--- a/commands/haytham.md
+++ b/commands/haytham.md
@@ -36,6 +36,7 @@ Mark the active item `in_progress` when starting the phase and `completed` when 
 | 1 | report-synthesizer | `phase-1-why/research-brief.md`, `phase-1-why/concept-anchor.json`, `phase-1-why/competitor-research.md`, `phase-1-why/founder-corrections.json` (if exists), `references/benchmarks.md` |
 | 2 | mvp-scoper | `phase-1-why/validation-report.md`, `phase-1-why/idea-analysis.md`, `phase-1-why/concept-anchor.json` |
 | 2 | capability-modeler | `phase-2-what/mvp-scope.md`, `phase-1-why/idea-analysis.md`, `phase-1-why/concept-anchor.json` |
+| 2 | capability-checker | `phase-2-what/mvp-scope.md`, `phase-2-what/capabilities.json`, `phase-1-why/concept-anchor.json` |
 | 3 | architect | `phase-2-what/capabilities.json`, `phase-2-what/system-traits.json`, `phase-2-what/mvp-scope.md` |
 | 4 | spec-generator | `phase-2-what/capabilities.json`, `phase-2-what/mvp-scope.md`, `phase-2-what/system-traits.json`, `phase-3-how/architecture-decisions.json`, `phase-3-how/build-buy.json`, `phase-1-why/concept-anchor.json` |
 | 5 | build (command) | `phase-4-specs/openspec/`, `phase-3-how/research-directives.json` |
@@ -380,20 +381,21 @@ Before launching any agents, tell the user:
 
 > **Phase 2: MVP Specification**
 >
-> This will run 4 steps:
+> This will run 5 steps:
 > 1. MVP Scope — define what's in, what's out, and the core flows (~1 min)
 > 2. Scope Review — you shape the scope before capabilities are derived ← YOU STEER HERE
 > 3. Capability Model — extract capabilities and system traits from your approved scope (~1 min)
-> 4. Gate 2 — you approve the final capabilities ← YOU DECIDE HERE
+> 4. Capability Review — an adversarial pass hunts for gaps in the model (~1 min)
+> 5. Gate 2 — you approve the final capabilities ← YOU DECIDE HERE
 >
-> Estimated total: ~4 minutes.
+> Estimated total: ~5 minutes.
 
 ### Step 7: MVP Scope
 
 Verify `.haytham/session/phase-1-why/gate-decision.json` exists.
 
 Tell the user:
-> **Step 1/4: MVP Scope**
+> **Step 1/5: MVP Scope**
 > Translating the validated idea into a concrete MVP definition. What's in, what's out, and what the core user flow looks like.
 
 Launch an **mvp-scoper** agent with this task:
@@ -444,11 +446,11 @@ Update state: `last_completed_step: 8`.
 ### Step 9: Capability Model
 
 Tell the user:
-> **Step 3/4: Capability Model**
+> **Step 3/5: Capability Model**
 > Scope approved. Now extracting the specific capabilities your MVP needs from the scope you just approved.
 
 Read `.haytham/session/phase-2-what/mvp-scope.md` and count the number of IN SCOPE items in the MVP Boundaries table. Then launch a **capability-modeler** agent with this task:
-> Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, and concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`. The MVP scope has [N] IN SCOPE items. Produce one functional capability per distinct user-observable behavior. Simple IN SCOPE items produce one capability. Complex items (multi-step pipelines, processes with multiple distinct behaviors) produce one per behavior, each referencing the same serves_scope_item. Write to `.haytham/session/phase-2-what/capabilities.json` and `.haytham/session/phase-2-what/system-traits.json`.
+> Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, and concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`. The MVP scope has [N] IN SCOPE items. Produce one functional capability per distinct user-observable behavior. Simple IN SCOPE items produce one capability. Complex items (multi-step pipelines, processes with multiple distinct behaviors) produce one per behavior, each referencing the same serves_scope_item. Write to `.haytham/session/phase-2-what/capabilities.json`, `.haytham/session/phase-2-what/system-traits.json`, and `.haytham/session/phase-2-what/gate-summary.md`.
 
 After the agent completes, read `.haytham/session/phase-2-what/capabilities.json` and `.haytham/session/phase-2-what/system-traits.json` and present a structured digest:
 
@@ -463,17 +465,69 @@ After the agent completes, read `.haytham/session/phase-2-what/capabilities.json
 
 Update state: `last_completed_step: 9`.
 
-### Step 10: Gate 2
+### Step 10: Capability Review
+
+A generation pass reliably under-produces capabilities. This step runs an adversarial reviewer that hunts for gaps the modeler missed, before Gate 2.
+
+Tell the user:
+> **Step 4/5: Capability Review**
+> Running an adversarial pass over the capability model: hunting for missing capabilities and criteria the approved scope already implies.
+
+Track two counters across this step: CHECKER_ROUNDS (number of checker runs) and ADDITIONS_ACCEPTED (number of proposals accepted). Maintain a REJECTED list of proposals the founder declined.
+
+**Checker loop** (maximum 3 checker runs; in BATCH_MODE, maximum 2):
+
+1. Launch a **capability-checker** agent with this task:
+   > Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, capabilities from `.haytham/session/phase-2-what/capabilities.json`, and concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`. This is round [CHECKER_ROUNDS + 1]. Previously rejected proposals (do not re-propose these, even reworded): [LIST EACH REJECTED PROPOSAL'S NAME AND DESCRIPTION, or "none"]. Audit the capability model for gaps implied by the approved scope. Write findings to `.haytham/session/phase-2-what/capability-review.json`.
+2. Increment CHECKER_ROUNDS. Read `.haytham/session/phase-2-what/capability-review.json`.
+3. **If `proposed_additions` is empty:** tell the user:
+   > **Capability review clean.** The checker found no gaps[ after N rounds]. Proceeding to Gate 2.
+
+   Exit the loop and proceed to Step 11.
+4. **If there are proposals and BATCH_MODE is true:** accept all of them. Tell the user:
+   > **Capability review (batch mode):** accepting [N] checker proposal(s): [list proposed_name values].
+
+   Add [N] to ADDITIONS_ACCEPTED and go to 6.
+5. **If there are proposals** (normal mode), present each one inline (the user must see this without expanding anything):
+   > **The checker found [N] gap(s) in the capability model:**
+   >
+   > **1. [proposed_name]** ([gap_class], [type])
+   > - Proposes: [proposed_description]
+   > - Scope item it serves: "[serves_scope_item]"
+   > - Implied by: "[implied_by]"
+   > - Why: [rationale]
+   >
+   > (Repeat for each proposal.)
+   >
+   > Accept or reject each: reply with numbers to accept (e.g. "1, 3"), "all", or "none".
+
+   Add declined proposals to REJECTED. Add the count of accepted proposals to ADDITIONS_ACCEPTED. **If the founder rejected everything**, proceed to Step 11.
+6. Re-launch the **capability-modeler** agent with this task:
+   > Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`, and the current capabilities from `.haytham/session/phase-2-what/capabilities.json`. The founder approved these additions from an adversarial review (treat them as authoritative corrections): [PASTE EACH ACCEPTED PROPOSAL: name, description, type, serves_scope_item, and target_capability for acceptance criteria]. Integrate them into the capability model. Do not remove or alter existing capabilities beyond these additions. Write updated files to `.haytham/session/phase-2-what/capabilities.json`, `.haytham/session/phase-2-what/system-traits.json`, and `.haytham/session/phase-2-what/gate-summary.md` (the summary must reflect the additions, not the pre-review model).
+
+   Then, if CHECKER_ROUNDS is below the cap, return to 1 (additions can expose new gaps — the loop stops when a run proposes nothing new or the cap is hit). If the cap is reached, tell the user and proceed to Step 11.
+
+Update state: `last_completed_step: 10`.
+
+### Step 11: Gate 2
 
 **If BATCH_MODE is true:** Auto-write gate decision with `user_decision: "batch-auto-approved"`. Tell the user:
 > **Gate 2 auto-approved (batch mode).** Proceeding to technical design.
 
-Update state: `last_completed_step: 10`. Skip to Phase 3.
+Update state: `last_completed_step: 11`. Skip to Phase 3.
 
-**Otherwise**, read `.haytham/session/phase-2-what/capabilities.json` and output the following inline in your response (the user must see this without expanding anything):
-- Functional capabilities with traceability to scope items
-- Non-functional capabilities
-- System traits classification
+**Otherwise**, read `.haytham/session/phase-2-what/gate-summary.md` and output it inline in your response, verbatim (the user must see this without expanding anything). Do not rewrite it, summarize it further, or substitute your own digest. The agent wrote it with the full context of what it cut and what it assumed; a re-render loses that.
+
+Then add one line pointing at the detail:
+> Full details: `.haytham/session/phase-2-what/capabilities.json` and `.haytham/session/phase-2-what/system-traits.json`.
+
+Record the exact text the founder is seeing, before asking the gate question:
+
+```bash
+shasum -a 256 .haytham/session/phase-2-what/gate-summary.md
+```
+
+Keep that digest as SUMMARY_SHA for the gate decision below.
 
 Ask:
 > **Review the capabilities. Specifically:**
@@ -485,8 +539,8 @@ Ask:
 
 **If the user requests changes:**
 1. Re-launch the **capability-modeler** agent with this task:
-   > Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`, and the current capabilities from `.haytham/session/phase-2-what/capabilities.json`. The user reviewed the capabilities and requested these changes: [PASTE THE USER'S EXACT CORRECTIONS HERE]. Revise the capability model to incorporate these changes. Write updated files to `.haytham/session/phase-2-what/capabilities.json` and `.haytham/session/phase-2-what/system-traits.json`.
-2. Read the updated files and present the revised digest
+   > Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`, and the current capabilities from `.haytham/session/phase-2-what/capabilities.json`. The user reviewed the capabilities and requested these changes: [PASTE THE USER'S EXACT CORRECTIONS HERE]. Revise the capability model to incorporate these changes. Write updated files to `.haytham/session/phase-2-what/capabilities.json`, `.haytham/session/phase-2-what/system-traits.json`, and `.haytham/session/phase-2-what/gate-summary.md`.
+2. Re-render the updated `.haytham/session/phase-2-what/gate-summary.md` inline and recompute SUMMARY_SHA
 3. Ask the user to review again. **Repeat until the user approves.**
 
 **When the user approves**, write gate decision:
@@ -497,14 +551,20 @@ Ask:
   "user_decision": "approved|rejected",
   "scope_revisions": 0,
   "capability_revisions": 0,
+  "checker_rounds": 0,
+  "checker_additions_accepted": 0,
+  "summary_shown": ".haytham/session/phase-2-what/gate-summary.md",
+  "summary_sha256": "[SUMMARY_SHA]",
   "notes": "Any user feedback",
   "decided_at": "[ISO timestamp]"
 }
 ```
 
-Set `scope_revisions` and `capability_revisions` to the number of times each was re-generated based on user corrections.
+Set `scope_revisions` and `capability_revisions` to the number of times each was re-generated based on user corrections. Set `checker_rounds` to CHECKER_ROUNDS and `checker_additions_accepted` to ADDITIONS_ACCEPTED from Step 10.
 
-Update state: `last_completed_step: 10`.
+Set `summary_sha256` to SUMMARY_SHA, the digest of the summary as it was rendered at the moment of approval, so the record names the exact text that was approved. In BATCH_MODE, run `shasum -a 256` on the file when writing the auto-approval and record both fields the same way.
+
+Update state: `last_completed_step: 11`.
 
 ---
 
@@ -523,7 +583,7 @@ Before launching any agents, tell the user:
 >
 > Estimated total: ~3 minutes.
 
-### Step 11: Architecture
+### Step 12: Architecture
 
 Verify `.haytham/session/phase-2-what/gate-decision.json` exists.
 
@@ -532,7 +592,7 @@ Tell the user:
 > Deciding what to build, what to buy, and how the pieces fit together.
 
 Launch an **architect** agent with this task:
-> Read the capabilities, MVP scope, and system traits. Produce build/buy analysis, architecture decisions, and research directives. Write to `.haytham/session/phase-3-how/build-buy.json`, `.haytham/session/phase-3-how/architecture-decisions.json`, and `.haytham/session/phase-3-how/research-directives.json`.
+> Read the capabilities, MVP scope, and system traits. Produce build/buy analysis, architecture decisions, research directives, and the founder-facing gate summary. Write to `.haytham/session/phase-3-how/build-buy.json`, `.haytham/session/phase-3-how/architecture-decisions.json`, `.haytham/session/phase-3-how/research-directives.json`, and `.haytham/session/phase-3-how/gate-summary.md`.
 
 After the agent completes, read `.haytham/session/phase-3-how/build-buy.json`, `.haytham/session/phase-3-how/architecture-decisions.json`, and `.haytham/session/phase-3-how/research-directives.json` and present a structured digest:
 
@@ -547,23 +607,27 @@ After the agent completes, read `.haytham/session/phase-3-how/build-buy.json`, `
 >
 > Full details: `.haytham/session/phase-3-how/build-buy.json`, `.haytham/session/phase-3-how/architecture-decisions.json`, and `.haytham/session/phase-3-how/research-directives.json` — review before approving.
 
-Update state: `last_completed_step: 11`.
+Update state: `last_completed_step: 12`.
 
-### Step 12: Review & Gate 3
+### Step 13: Review & Gate 3
 
 **If BATCH_MODE is true:** Auto-write gate decision with `user_decision: "batch-auto-approved"`. Tell the user:
 > **Gate 3 auto-approved (batch mode).** Proceeding to spec generation.
 
-Update state: `last_completed_step: 12`. Skip to Phase 4.
+Update state: `last_completed_step: 13`. Skip to Phase 4.
 
-**Otherwise**, read all three output files and output the following inline in your response (the user must see this without expanding anything):
-- **Recommended Stack**: Service name, category, BUILD/BUY/HYBRID, rationale
-- **Architecture Decisions**: ID, name, what it covers, capabilities served
-- **Research Directives:** [N] of [M] capabilities require pre-implementation research
-  - CAP-F-NNN (Capability Name): classification(s) — N questions
-  - (Repeat for each non-standard capability)
-- **Integration Effort**: Estimated days
-- **Monthly Cost**: Estimated range
+**Otherwise**, read `.haytham/session/phase-3-how/gate-summary.md` and output it inline in your response, verbatim (the user must see this without expanding anything). Do not rewrite it, summarize it further, or substitute your own digest. The agent wrote it knowing which alternatives it rejected and which unknowns remain; a re-render loses that.
+
+Then add one line pointing at the detail:
+> Full details: `.haytham/session/phase-3-how/build-buy.json`, `.haytham/session/phase-3-how/architecture-decisions.json`, and `.haytham/session/phase-3-how/research-directives.json`.
+
+Record the exact text the founder is seeing, before asking the gate question:
+
+```bash
+shasum -a 256 .haytham/session/phase-3-how/gate-summary.md
+```
+
+Keep that digest as SUMMARY_SHA for the gate decision below.
 
 Ask:
 > **Review the technical design. Specifically:**
@@ -579,12 +643,16 @@ Write gate decision:
 {
   "phase": 3,
   "user_decision": "approved|rejected",
+  "summary_shown": ".haytham/session/phase-3-how/gate-summary.md",
+  "summary_sha256": "[SUMMARY_SHA]",
   "notes": "Any user feedback",
   "decided_at": "[ISO timestamp]"
 }
 ```
 
-Update state: `last_completed_step: 12`.
+Set `summary_sha256` to SUMMARY_SHA, the digest of the summary as it was rendered at the moment of approval, so the record names the exact text that was approved. In BATCH_MODE, run `shasum -a 256` on the file when writing the auto-approval and record both fields the same way.
+
+Update state: `last_completed_step: 13`.
 
 ---
 
@@ -603,7 +671,7 @@ Before launching any agents, tell the user:
 >
 > Estimated total: ~3 minutes.
 
-### Step 13: OpenSpec Generation
+### Step 14: OpenSpec Generation
 
 Verify `.haytham/session/phase-3-how/gate-decision.json` exists.
 
@@ -633,14 +701,14 @@ Then read the generated files and present a structured digest:
 >
 > Full details: `.haytham/session/phase-4-specs/openspec/` — review before approving.
 
-Update state: `last_completed_step: 13`.
+Update state: `last_completed_step: 14`.
 
-### Step 14: Final Review
+### Step 15: Final Review
 
 **If BATCH_MODE is true:** Skip the review. Tell the user:
 > **Final review skipped (batch mode).** Specification complete.
 
-Update state: `last_completed_step: 14`. Skip to Completion.
+Update state: `last_completed_step: 15`. Skip to Completion.
 
 **Otherwise**, read the OpenSpec files and output the following inline in your response (the user must see this without expanding anything):
 - Domain list with requirement counts per domain
@@ -655,7 +723,7 @@ Ask:
 >
 > Say "looks good" or request changes.
 
-Update state: `last_completed_step: 14`.
+Update state: `last_completed_step: 15`.
 
 ### Completion
 
@@ -671,4 +739,4 @@ Command               Output Directory
 
 Tell the user:
 
-> Your specification is complete. Ran 9 agents across 4 phases. All output files are in `.haytham/session/`. Run `/haytham:build` to set up your project for implementation with OpenSpec.
+> Your specification is complete. Ran 10 agents across 4 phases. All output files are in `.haytham/session/`. Run `/haytham:build` to set up your project for implementation with OpenSpec.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -107,11 +107,13 @@ Phase 2 (WHAT): .haytham/session/phase-2-what/
   - mvp-scope.md - MVP scope and boundaries
   - capabilities.json - Capability model
   - system-traits.json - System classification
+  - gate-summary.md - What you approved at Gate 2
 
 Phase 3 (HOW): .haytham/session/phase-3-how/
   - build-buy.json - Infrastructure decisions
   - architecture-decisions.json - Architecture choices
   - research-directives.json - Pre-implementation research questions
+  - gate-summary.md - What you approved at Gate 3
 
 Phase 4 (SPECS): .haytham/session/phase-4-specs/openspec/
   - config.yaml - Project metadata and system traits

--- a/commands/specify.md
+++ b/commands/specify.md
@@ -17,7 +17,8 @@ After prerequisites pass, call `TodoWrite` once with:
 1. Step 1 — MVP scope
 2. Step 2 — Scope review (founder)
 3. Step 3 — Capability model
-4. Step 4 — Gate 2
+4. Step 4 — Capability review (checker)
+5. Step 5 — Gate 2
 
 Mark each todo `in_progress` when its step begins and `completed` when its output file is written or its gate decision is recorded. If the founder requests scope or capability revisions, set the relevant todo back to `in_progress` for the re-run.
 
@@ -35,20 +36,21 @@ Before launching any agents, tell the user:
 
 > **Phase 2: MVP Specification**
 >
-> This will run 4 steps:
+> This will run 5 steps:
 > 1. MVP Scope — define what's in, what's out, and the core flows (~1 min)
 > 2. Scope Review — you shape the scope before capabilities are derived ← YOU STEER HERE
 > 3. Capability Model — extract capabilities and system traits from your approved scope (~1 min)
-> 4. Gate 2 — you approve the final capabilities ← YOU DECIDE HERE
+> 4. Capability Review — an adversarial pass hunts for gaps in the model (~1 min)
+> 5. Gate 2 — you approve the final capabilities ← YOU DECIDE HERE
 >
-> Estimated total: ~4 minutes.
+> Estimated total: ~5 minutes.
 
 ## Step 1: MVP Scope
 
 Create `.haytham/session/phase-2-what/` directory if it doesn't exist.
 
 Tell the user:
-> **Step 1/4: MVP Scope**
+> **Step 1/5: MVP Scope**
 > Translating the validated idea into a concrete MVP definition. What's in, what's out, and what the core user flow looks like.
 
 Launch an **mvp-scoper** agent with this task:
@@ -90,11 +92,11 @@ Ask:
 ## Step 3: Capability Model & System Traits
 
 Tell the user:
-> **Step 3/4: Capability Model**
+> **Step 3/5: Capability Model**
 > Scope approved. Now extracting the specific capabilities your MVP needs from the scope you just approved.
 
 Read `.haytham/session/phase-2-what/mvp-scope.md` and count the number of IN SCOPE items in the MVP Boundaries table. Then launch a **capability-modeler** agent with this task:
-> Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, and concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`. The MVP scope has [N] IN SCOPE items. Produce one functional capability per distinct user-observable behavior. Simple IN SCOPE items produce one capability. Complex items (multi-step pipelines, processes with multiple distinct behaviors) produce one per behavior, each referencing the same serves_scope_item. Write to `.haytham/session/phase-2-what/capabilities.json` and `.haytham/session/phase-2-what/system-traits.json`.
+> Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, and concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`. The MVP scope has [N] IN SCOPE items. Produce one functional capability per distinct user-observable behavior. Simple IN SCOPE items produce one capability. Complex items (multi-step pipelines, processes with multiple distinct behaviors) produce one per behavior, each referencing the same serves_scope_item. Write to `.haytham/session/phase-2-what/capabilities.json`, `.haytham/session/phase-2-what/system-traits.json`, and `.haytham/session/phase-2-what/gate-summary.md`.
 
 After the agent completes, read `.haytham/session/phase-2-what/capabilities.json` and `.haytham/session/phase-2-what/system-traits.json` and present a structured digest:
 
@@ -107,12 +109,58 @@ After the agent completes, read `.haytham/session/phase-2-what/capabilities.json
 >
 > Full details: `.haytham/session/phase-2-what/capabilities.json` and `.haytham/session/phase-2-what/system-traits.json` — review before approving.
 
-## Step 4: Gate 2
+## Step 4: Capability Review
 
-Read `.haytham/session/phase-2-what/capabilities.json` and output the following inline in your response (the user must see this without expanding anything):
-- Functional capabilities with traceability to scope items
-- Non-functional capabilities
-- System traits classification
+A generation pass reliably under-produces capabilities. This step runs an adversarial reviewer that hunts for gaps the modeler missed, before you approve at Gate 2.
+
+Tell the user:
+> **Step 4/5: Capability Review**
+> Running an adversarial pass over the capability model: hunting for missing capabilities and criteria the approved scope already implies.
+
+Track two counters across this step: CHECKER_ROUNDS (number of checker runs) and ADDITIONS_ACCEPTED (number of proposals you accepted). Maintain a REJECTED list of proposals the founder declined.
+
+**Checker loop** (maximum 3 checker runs):
+
+1. Launch a **capability-checker** agent with this task:
+   > Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, capabilities from `.haytham/session/phase-2-what/capabilities.json`, and concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`. This is round [CHECKER_ROUNDS + 1]. Previously rejected proposals (do not re-propose these, even reworded): [LIST EACH REJECTED PROPOSAL'S NAME AND DESCRIPTION, or "none"]. Audit the capability model for gaps implied by the approved scope. Write findings to `.haytham/session/phase-2-what/capability-review.json`.
+2. Increment CHECKER_ROUNDS. Read `.haytham/session/phase-2-what/capability-review.json`.
+3. **If `proposed_additions` is empty:** tell the user:
+   > **Capability review clean.** The checker found no gaps[ after N rounds]. Proceeding to Gate 2.
+
+   Exit the loop and proceed to Step 5.
+4. **If there are proposals**, present each one inline (the user must see this without expanding anything):
+   > **The checker found [N] gap(s) in the capability model:**
+   >
+   > **1. [proposed_name]** ([gap_class], [type])
+   > - Proposes: [proposed_description]
+   > - Scope item it serves: "[serves_scope_item]"
+   > - Implied by: "[implied_by]"
+   > - Why: [rationale]
+   >
+   > (Repeat for each proposal.)
+   >
+   > Accept or reject each: reply with numbers to accept (e.g. "1, 3"), "all", or "none".
+5. Add declined proposals to REJECTED. Add the count of accepted proposals to ADDITIONS_ACCEPTED.
+6. **If the founder accepted any proposals**, re-launch the **capability-modeler** agent with this task:
+   > Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`, and the current capabilities from `.haytham/session/phase-2-what/capabilities.json`. The founder approved these additions from an adversarial review (treat them as authoritative corrections): [PASTE EACH ACCEPTED PROPOSAL: name, description, type, serves_scope_item, and target_capability for acceptance criteria]. Integrate them into the capability model. Do not remove or alter existing capabilities beyond these additions. Write updated files to `.haytham/session/phase-2-what/capabilities.json`, `.haytham/session/phase-2-what/system-traits.json`, and `.haytham/session/phase-2-what/gate-summary.md` (the summary must reflect the additions, not the pre-review model).
+
+   Then, if CHECKER_ROUNDS < 3, return to 1 (additions can expose new gaps — the loop stops when a run proposes nothing new or the cap is hit). If CHECKER_ROUNDS is already 3, tell the user the round cap was reached and proceed to Step 5.
+7. **If the founder rejected everything**, proceed to Step 5.
+
+## Step 5: Gate 2
+
+Read `.haytham/session/phase-2-what/gate-summary.md` and output it inline in your response, verbatim (the user must see this without expanding anything). Do not rewrite it, summarize it further, or substitute your own digest. The agent wrote it with the full context of what it cut and what it assumed; a re-render loses that.
+
+Then add one line pointing at the detail:
+> Full details: `.haytham/session/phase-2-what/capabilities.json` and `.haytham/session/phase-2-what/system-traits.json`.
+
+Record the exact text the founder is seeing, before asking the gate question:
+
+```bash
+shasum -a 256 .haytham/session/phase-2-what/gate-summary.md
+```
+
+Keep that digest as SUMMARY_SHA for the gate decision below.
 
 Ask:
 > **Review the capabilities. Specifically:**
@@ -124,8 +172,8 @@ Ask:
 
 **If the user requests changes:**
 1. Re-launch the **capability-modeler** agent with this task:
-   > Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`, and the current capabilities from `.haytham/session/phase-2-what/capabilities.json`. The user reviewed the capabilities and requested these changes: [PASTE THE USER'S EXACT CORRECTIONS HERE]. Revise the capability model to incorporate these changes. Write updated files to `.haytham/session/phase-2-what/capabilities.json` and `.haytham/session/phase-2-what/system-traits.json`.
-2. Read the updated files and present the revised digest
+   > Read the MVP scope from `.haytham/session/phase-2-what/mvp-scope.md`, idea analysis from `.haytham/session/phase-1-why/idea-analysis.md`, concept anchor from `.haytham/session/phase-1-why/concept-anchor.json`, and the current capabilities from `.haytham/session/phase-2-what/capabilities.json`. The user reviewed the capabilities and requested these changes: [PASTE THE USER'S EXACT CORRECTIONS HERE]. Revise the capability model to incorporate these changes. Write updated files to `.haytham/session/phase-2-what/capabilities.json`, `.haytham/session/phase-2-what/system-traits.json`, and `.haytham/session/phase-2-what/gate-summary.md`.
+2. Re-render the updated `.haytham/session/phase-2-what/gate-summary.md` inline and recompute SUMMARY_SHA
 3. Ask the user to review again. **Repeat until the user approves.**
 
 **When the user approves**, write gate decision to `.haytham/session/phase-2-what/gate-decision.json`:
@@ -135,11 +183,17 @@ Ask:
   "user_decision": "approved|rejected",
   "scope_revisions": 0,
   "capability_revisions": 0,
+  "checker_rounds": 0,
+  "checker_additions_accepted": 0,
+  "summary_shown": ".haytham/session/phase-2-what/gate-summary.md",
+  "summary_sha256": "[SUMMARY_SHA]",
   "notes": "Any user feedback",
   "decided_at": "[ISO timestamp]"
 }
 ```
 
-Set `scope_revisions` and `capability_revisions` to the number of times each was re-generated based on user corrections. This tracks how much steering was needed.
+Set `scope_revisions` and `capability_revisions` to the number of times each was re-generated based on user corrections. Set `checker_rounds` to CHECKER_ROUNDS and `checker_additions_accepted` to ADDITIONS_ACCEPTED from Step 4. This tracks how much steering was needed and how much the checker caught.
 
-Tell the user: "Phase 2 complete. Output saved to `.haytham/session/phase-2-what/`. Run `/haytham:design` to proceed to Phase 3."
+Set `summary_sha256` to SUMMARY_SHA, the digest of the summary as it was rendered at the moment of approval. The approval record then names the exact text the founder read, and a later edit to the file is detectable.
+
+Tell the user: "Phase 2 complete. Output saved to `.haytham/session/phase-2-what/` (`mvp-scope.md`, `capabilities.json`, `system-traits.json`, `gate-summary.md`). Run `/haytham:design` to proceed to Phase 3."

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -30,9 +30,11 @@ flowchart TD
 
     subgraph what["WHAT: What exactly?"]
         mvp[MVP Scoper] --> capability[Capability Modeler]
+        capability --> checker[Capability Checker]
+        checker -->|gaps found| capability
     end
 
-    capability --> gate2{Gate 2: Product Owner}
+    checker --> gate2{Gate 2: Product Owner}
     gate2 -->|Approved| build_buy
 
     subgraph how["HOW: How?"]
@@ -89,7 +91,11 @@ Define a focused, achievable first version. The **MVP Scoper** uses Shape Up app
 
 The **Capability Modeler** decomposes the scope into functional and non-functional capabilities using standard capability mapping, each traced to the user flows that justify it. It also classifies system traits (interface type, auth model, deployment targets, data layer) to inform downstream architecture. Without this classification, spec generation defaults to web-app patterns regardless of whether the product is a CLI tool, an API service, or a mobile app.
 
+The **Capability Checker** then audits the model adversarially. A generation pass reliably under-produces capabilities, so a second agent with a destructive mandate hunts for gaps the approved scope already implies: undefined load-bearing terms ("confirmed", "valid"), missing failure surfacing in unattended systems, success metrics no capability produces, flow steps no capability covers. It can only propose additions that quote an existing in-scope item, which keeps it from becoming a scope-creep vector. The founder accepts or rejects each proposal, accepted ones go back through the modeler, and the checker re-runs until a pass finds nothing new (capped at 3 rounds).
+
 ### Gate 2: Product Owner Review
+
+The modeler writes `gate-summary.md` alongside the JSON, and the gate renders that file verbatim. It carries what the JSON cannot hold: the behaviors that were cut, the calls that could have gone the other way, and the questions the approved scope left open. The decision record then stores the summary path and a SHA-256 of the text, so the approval names exactly what was read.
 
 - **Approved**: Scope is locked, proceed to technical design
 - **Revise**: Adjust scope boundaries or capabilities
@@ -101,6 +107,8 @@ The **Capability Modeler** decomposes the scope into functional and non-function
 The **Architect** evaluates each capability for build-vs-buy using a weighted scoring model (complexity, time-to-build, maintenance burden, cost-at-scale, vendor lock-in risk, and differentiation value). It recommends BUILD, BUY, or HYBRID per capability. It then records key technical decisions (component structure, technology stack, integration patterns, deployment approach) as DEC-* records with rationale and the capabilities each serves.
 
 ### Gate 3: Architect Review
+
+The architect writes `gate-summary.md` the same way: the stack in plain language, the three to five decisions with the highest cost of being wrong, what it costs to run, and the unknowns that still block implementation. The gate renders that file and records its digest in the decision.
 
 - **Approved**: Architecture locked, proceed to specification generation
 - **Revise**: Adjust technology or integration decisions
@@ -128,6 +136,7 @@ The OpenSpec in `.haytham/session/phase-4-specs/openspec/` is a complete, self-c
 | Report Synthesizer | WHY | Score dimensions, produce GO/NO-GO/PIVOT verdict | opus |
 | MVP Scoper | WHAT | Scope definition, boundaries, core flows | sonnet |
 | Capability Modeler | WHAT | Capability extraction and system trait classification | sonnet |
+| Capability Checker | WHAT | Adversarial gap review of the capability model | sonnet |
 | Architect | HOW | Build/buy analysis and architecture decisions | sonnet |
 | Spec Generator | SPECS | OpenSpec generation with SHALL statements and Gherkin scenarios | opus |
 
@@ -152,12 +161,15 @@ Each phase writes structured output to `.haytham/session/`. Phases read upstream
     mvp-scope.md                  # Scope, boundaries, core flows
     capabilities.json             # CAP-F-*, CAP-NF-*
     system-traits.json            # System trait classification
-    gate-decision.json
+    capability-review.json        # Adversarial gap findings
+    gate-summary.md               # Founder-readable summary rendered at Gate 2
+    gate-decision.json            # Decision, plus the summary path and digest
   phase-3-how/
     build-buy.json                # BUILD/BUY/HYBRID per capability
     architecture-decisions.json   # DEC-* decisions
     research-directives.json      # What to investigate before coding
-    gate-decision.json
+    gate-summary.md               # Founder-readable summary rendered at Gate 3
+    gate-decision.json            # Decision, plus the summary path and digest
   phase-4-specs/
     openspec/
       config.yaml                 # Project metadata, system traits

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -95,7 +95,7 @@ The **Capability Checker** then audits the model adversarially. A generation pas
 
 ### Gate 2: Product Owner Review
 
-The modeler writes `gate-summary.md` alongside the JSON, and the gate renders that file verbatim. It carries what the JSON cannot hold: the behaviors that were cut, the calls that could have gone the other way, and the questions the approved scope left open. The decision record then stores the summary path and a SHA-256 of the text, so the approval names exactly what was read.
+The modeler writes `gate-summary.md` alongside the JSON, and the gate renders that file verbatim. It carries what the JSON cannot hold: the behaviors that were cut, the calls that could have gone the other way, and the questions the approved scope left open. The decision record then stores the summary path and a SHA-256 of the text, so the approval names exactly what was read. The validator re-hashes the file on every write and warns if the two ever disagree, which is what makes a post-approval edit detectable rather than merely recorded.
 
 - **Approved**: Scope is locked, proceed to technical design
 - **Revise**: Adjust scope boundaries or capabilities

--- a/docs/plans/2026-07-27-gate-summaries.md
+++ b/docs/plans/2026-07-27-gate-summaries.md
@@ -1,0 +1,125 @@
+# Founder-readable gate summaries (issue #72)
+
+## Context
+
+Gates 2 and 3 ask the founder to approve work whose only on-disk form is JSON: `phase-2-what/capabilities.json`, `system-traits.json`, `phase-3-how/build-buy.json`, `architecture-decisions.json`, `research-directives.json`. The commands do render a digest inline at the gate (`commands/specify.md:101-110`, `commands/design.md:65-74`), but that digest is composed on the fly by whichever session is orchestrating, its quality varies, and it is never written to disk. The approval record in `gate-decision.json` therefore does not say what the founder actually read. Phase 1 does not have this problem because `validation-report.md` is already prose.
+
+Outcome: each of the two gates gets a persisted, agent-authored `gate-summary.md`, the gate renders that file instead of improvising, and `gate-decision.json` records the path plus a SHA-256 of the exact text that was approved.
+
+Decisions already taken:
+- The specialist agent that owns the JSON writes the summary in the same pass. It is the only actor that knows the cuts it made and the questions it could not resolve, and none of that is in the JSON. Precedent: `agents/report-synthesizer.md:33` already produces `validation-report.md` and `validation-report.json` from one agent, with an explicit cross-artifact consistency rule at `:213`. `agents/feasibility-screener.md:75` does the lighter version of the same thing.
+- Scope is Gate 2 and Gate 3 only. Phase 1 already ships prose, Phase 4 has no `gate-decision.json` at all.
+- Provenance goes in `gate-decision.json` as `summary_shown` + `summary_sha256`.
+
+## Artifact contract
+
+One filename, both phases: `.haytham/session/phase-2-what/gate-summary.md` and `.haytham/session/phase-3-how/gate-summary.md`. Same name because it is the same concept (the thing rendered at a gate), and `gate-decision.json` sits next to it in both dirs.
+
+Phase 2 sections (written by capability-modeler):
+
+```markdown
+# What we are building
+[2-3 sentences: system purpose, who it is for]
+## What is in
+[one bullet per functional capability: name, what the founder gets, the IN SCOPE item it serves]
+## What is out
+[IN SCOPE items with no capability, and notable cuts, each with the reason]
+## Judgment calls
+[decisions that could reasonably have gone the other way, e.g. why two behaviors were kept as one capability]
+## Open questions
+[what the scope did not settle; "None" if empty]
+```
+
+Phase 3 sections (written by architect):
+
+```markdown
+# How we are building it
+[2-3 sentences: shape of the system]
+## The stack
+[per component: name, BUILD/BUY/HYBRID, one line of why]
+## Decisions that matter
+[3-5 decisions a founder would regret getting wrong, each with the alternative that was rejected]
+## What this costs
+[monthly cost range, integration effort]
+## Unknowns to resolve before building
+[each research directive with research_required true, as a plain question]
+```
+
+Constraints to state in both agent prompts: prose only, no JSON blocks, under 600 words, no em dashes (`AGENTS.md:139-147`), no vendor API surface (`agents/architect.md:179`, `:218-235`), and explicitly **for the founder only, no downstream agent reads it** so it never becomes a re-derivation input (`AGENTS.md:195-197`).
+
+Tone: reuse the founder-persona switch that `agents/report-synthesizer.md:54-60` and `:82-88` already define, reading `founder_profile` from `concept-anchor.json`. Both agents already read that file, so this costs nothing. Copy the rule, do not invent a second tone standard.
+
+## Changes
+
+### 1. Agents write the artifact
+
+- `agents/capability-modeler.md`: add a Part 3 after the system-traits part with the section template above, and add `.haytham/session/phase-2-what/gate-summary.md` to the File I/O **Write to** block (`:240-242`). Add one self-check bullet: every functional capability appears in "What is in".
+- `agents/architect.md`: add a Part 4 after research directives with the template above, and add the path to the File I/O **Write to** block (`:398-401`). Tools are already `Read, Write`, no frontmatter change.
+
+### 2. Commands name the artifact in every launch prompt
+
+The agent contract alone is not enough: the launch prompts enumerate write targets, and a prompt that lists two files while the agent lists three invites the agent to skip one. Append `and .haytham/session/phase-{N}/gate-summary.md` to every site that launches these agents:
+
+- `commands/specify.md:99` (initial), `:145` (checker re-run), `:167` (gate revision)
+- `commands/design.md:50`
+- `commands/haytham.md:453`, `:506`, `:534` (phase 2 mirrors), `:583` (phase 3)
+
+The dependency table at `commands/haytham.md:29-45` lists reads only, so it needs no change.
+
+### 3. Gates render the file instead of improvising
+
+- `commands/specify.md` Step 5 (`:152-155`): replace "Read `capabilities.json` and output the following inline" with "Read `.haytham/session/phase-2-what/gate-summary.md` and output it inline, verbatim. Then point at the JSON files for detail." Keep the existing gate questions (`:157-163`) unchanged.
+- `commands/design.md` Step 2 (`:65-74`): same substitution against `phase-3-how/gate-summary.md`. Step 1's digest (`:55-63`) stays, it is a progress message, not the gate.
+- `commands/haytham.md:519` (Gate 2) and `:600-611` (Step 13 Review) get the identical substitution. Batch mode branches (`:515`, `:603`) still write the summary, they just skip the human.
+
+### 4. Provenance in gate-decision.json
+
+Add to the JSON template at `commands/specify.md:171-183` and `commands/design.md:86-93` (and the mirrors at `commands/haytham.md:540`, `:624`):
+
+```json
+"summary_shown": ".haytham/session/phase-2-what/gate-summary.md",
+"summary_sha256": "[shasum -a 256 of the file as shown]"
+```
+
+Both commands already have `Bash` in `allowed-tools`, so `shasum -a 256 <path>` is available. Instruct: compute the hash immediately after rendering, before asking the gate question, so a later edit to the summary is detectable.
+
+### 5. Validation
+
+`scripts/validate_schema.py`:
+- New `if basename == "gate-summary.md"` branch in `validate_markdown()` (`:71-258`). Dispatch is by basename only, so branch on the parent directory inside it to pick the required section list per phase. Warn on: missing required section, a ```` ```json ```` fence (means the agent dumped the artifact instead of summarizing), word count over 600.
+- Phase 2 coverage check: open the sibling `capabilities.json` and warn for any functional capability `name` that does not appear in the summary text. `research-brief.md` already reads sibling files this way (`:163`), so the pattern exists.
+- `gate-decision.json`: leave `SCHEMAS` (`:19-36`) alone, the new fields are additive. Add a phase-aware check: if `phase` is 2 or 3 and `summary_shown` is absent, warn. Warnings are non-blocking by design (`:9`).
+
+`tests/test_plugin_sanity.py`, in `TestSchemaValidation` (`:246+`), with new fixtures under `tests/fixtures/`:
+- `valid_gate_summary_phase2.md` and a missing-section variant
+- a phase-2 summary that omits a capability present in `capabilities_for_cross_check.json`
+- `gate_decision_no_summary.json` at phase 2, expect the warning; a phase 1 one, expect none
+
+### 6. Downstream and docs
+
+- `commands/build.md:68`: add `gate-summary.md` to the **Do NOT copy** list, same treatment as `gate-decision.json`. It is a gate rendering, and the JSON it summarizes is already copied. The "all 10 files" count at `:85` stays correct.
+- `commands/plan.md:106-114`: add the two `gate-summary.md` lines to the Phase 2 and Phase 3 blocks of the completion inventory.
+- Completion messages that enumerate outputs: `commands/specify.md:187`, `commands/design.md:96`, and the `haytham.md` equivalents.
+- Three copies of the artifact tree, all of which drift already: `README.md:63-90`, `docs/how-it-works.md:144-172`, `docs/getting-started.md:36-46`. Add one sentence to the `docs/how-it-works.md` Gate 2 and Gate 3 sections saying each gate now renders a persisted summary.
+- Optional, after the end-to-end run: drop the produced `gate-summary.md` files into `examples/gym-leaderboard/` and list them in that example's README table, matching how `mvp-scope.md` and `validation-report.md` are already shown there.
+- Bump `plugins[0].version` in `.claude-plugin/marketplace.json` (currently `0.4.0`).
+- The repo keeps plan documents in `docs/plans/YYYY-MM-DD-slug.md`. Land this plan as `docs/plans/2026-07-27-gate-summaries.md` so the decision trail stays in the repo, and reference issue #72 in the commit.
+
+## Risks
+
+- **`haytham.md` drift.** Phase 2 and 3 logic is duplicated between the standalone commands and `commands/haytham.md`, and the copies have already drifted (`design.md:73` says "N findings resolved, N questions remaining" where `haytham.md:611` says "N questions"). Every edit above must land in both. Merging those files is a real fix but is out of scope here.
+- **Prose drifting from JSON.** Mitigated by same-pass authorship plus the coverage warning, not eliminated. Accepted: the summary carries cuts and open questions that the JSON does not hold, so it cannot be a pure projection.
+- **In-flight working tree.** `commands/specify.md`, `commands/haytham.md`, `AGENTS.md`, `docs/how-it-works.md` and the new `agents/capability-checker.md` are uncommitted (issue #71 work). Line numbers above are against the working tree, not HEAD. Land or stash that first.
+
+## Verification
+
+1. `python3 -m pytest tests/test_plugin_sanity.py -v` passes, including the new schema cases.
+2. Direct validator exercise: write a deliberately broken `gate-summary.md` under a temp `.haytham/session/phase-2-what/` and call `validate_file()` on it, confirm each warning fires and that a good file produces none.
+3. End to end on a real idea, which is the only check that proves the agents actually write the file:
+   ```
+   /haytham "a gym community leaderboard with anonymous handles"
+   ```
+   Confirm: both `gate-summary.md` files exist, each gate printed the file contents inline rather than an improvised digest, the sections are populated (not template placeholders), `gate-decision.json` in both phases carries `summary_shown` and a `summary_sha256` matching `shasum -a 256` of the file on disk.
+4. Second run on a different product class (a CLI tool) to confirm the section templates are not web-app specific (`AGENTS.md:47`).
+5. Run the phase 2 checker loop with at least one accepted proposal and confirm the re-run rewrites `gate-summary.md` rather than leaving the pre-addition version.
+6. `/haytham:build` into a scratch dir: confirm `gate-summary.md` is not copied into `openspec/context/` and the context table still lists 10 files.

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -255,6 +255,88 @@ def validate_markdown(file_path: str) -> list[str]:
                     f"(budget: {budget}, 25% tolerance: {int(budget * 1.25)})"
                 )
 
+    # --- gate-summary.md (founder-facing gate artifact) ---
+    if basename == "gate-summary.md":
+        warnings.extend(_validate_gate_summary(file_path, content))
+
+    return warnings
+
+
+# Required sections per phase directory. Dispatch in validate_markdown() is by
+# basename, and both phases use the same filename, so the phase comes from the
+# parent directory.
+GATE_SUMMARY_SECTIONS = {
+    "phase-2-what": [
+        (r"^#+\s*What is in\b", "What is in"),
+        (r"^#+\s*What is out\b", "What is out"),
+        (r"^#+\s*Judgment calls\b", "Judgment calls"),
+        (r"^#+\s*Open questions\b", "Open questions"),
+    ],
+    "phase-3-how": [
+        (r"^#+\s*The stack\b", "The stack"),
+        (r"^#+\s*Decisions that matter\b", "Decisions that matter"),
+        (r"^#+\s*What this costs\b", "What this costs"),
+        (r"^#+\s*Unknowns to resolve\b", "Unknowns to resolve before building"),
+    ],
+}
+
+GATE_SUMMARY_WORD_CAP = 600
+
+
+def _validate_gate_summary(file_path: str, content: str) -> list[str]:
+    """Validate a phase gate summary. Returns warnings.
+
+    The summary is what the founder reads at the gate, so the checks are about
+    comprehension: the decision sections are present, it is prose rather than a
+    JSON dump, and it stays short enough to actually be read.
+    """
+    warnings = []
+    phase_dir = os.path.basename(os.path.dirname(file_path))
+
+    required_sections = GATE_SUMMARY_SECTIONS.get(phase_dir)
+    if required_sections is None:
+        # A gate summary outside a known phase directory: nothing to check against.
+        return warnings
+
+    for pattern, name in required_sections:
+        if not re.search(pattern, content, re.MULTILINE | re.IGNORECASE):
+            warnings.append(f"gate-summary.md ({phase_dir}): Missing section '{name}'")
+
+    if re.search(r"^```json", content, re.MULTILINE):
+        warnings.append(
+            f"gate-summary.md ({phase_dir}): Contains a JSON block. The summary is "
+            "for the founder; the JSON artifacts hold the machine-readable detail."
+        )
+
+    words = len(content.split())
+    if words > GATE_SUMMARY_WORD_CAP:
+        warnings.append(
+            f"gate-summary.md ({phase_dir}): {words} words "
+            f"(cap: {GATE_SUMMARY_WORD_CAP})"
+        )
+
+    # Phase 2 coverage: every functional capability the founder is approving must
+    # be named in the summary, otherwise the gate hides part of what it approves.
+    if phase_dir == "phase-2-what":
+        caps_path = os.path.join(os.path.dirname(file_path), "capabilities.json")
+        if os.path.exists(caps_path):
+            try:
+                with open(caps_path) as cf:
+                    caps = json.load(cf)
+            except (OSError, json.JSONDecodeError):
+                caps = None
+            if isinstance(caps, dict):
+                functional = caps.get("capabilities", {}).get("functional", [])
+                for cap in functional:
+                    if not isinstance(cap, dict):
+                        continue
+                    name = cap.get("name", "")
+                    if name and name.lower() not in content.lower():
+                        warnings.append(
+                            f"gate-summary.md ({phase_dir}): Capability '{name}' "
+                            "from capabilities.json is not mentioned"
+                        )
+
     return warnings
 
 
@@ -297,6 +379,20 @@ def validate_file(file_path: str) -> list[str]:
             warnings.append(f"Missing required field '{key}' in {basename}")
         elif data[key] is None or data[key] == "" or data[key] == []:
             warnings.append(f"Empty required field '{key}' in {basename}")
+
+    # Gates 2 and 3 render a persisted founder summary, so their decision record
+    # must name the text that was approved.
+    if basename == "gate-decision.json" and data.get("phase") in (2, 3):
+        if not data.get("summary_shown"):
+            warnings.append(
+                f"Missing 'summary_shown' in {basename} (phase {data.get('phase')}). "
+                "The gate decision should record the gate-summary.md the founder read."
+            )
+        elif not data.get("summary_sha256"):
+            warnings.append(
+                f"Missing 'summary_sha256' in {basename} (phase {data.get('phase')}). "
+                "Without the digest, a later edit to the summary is undetectable."
+            )
 
     # Special validation for concept-anchor.json
     if basename == "concept-anchor.json":

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -9,6 +9,7 @@ Checks:
 Outputs warnings to stderr (non-blocking). Exit 0 always.
 """
 
+import hashlib
 import json
 import os
 import re
@@ -340,6 +341,52 @@ def _validate_gate_summary(file_path: str, content: str) -> list[str]:
     return warnings
 
 
+def _check_summary_digest(file_path: str, data: dict) -> list[str]:
+    """Re-hash the gate summary and compare against the recorded digest.
+
+    The point of storing summary_sha256 is that an edit to the summary after
+    approval becomes detectable. Checking only that the field is non-empty
+    would leave the digest decorative, so recompute it here.
+
+    file_path is the gate-decision.json path; the summary is its sibling.
+    """
+    warnings = []
+    phase_dir = os.path.dirname(file_path)
+    summary_path = os.path.join(phase_dir, "gate-summary.md")
+
+    shown = data.get("summary_shown", "")
+    if os.path.basename(shown) != "gate-summary.md":
+        warnings.append(
+            f"'summary_shown' points at '{shown}', not the gate-summary.md "
+            f"beside gate-decision.json in {os.path.basename(phase_dir)}"
+        )
+        return warnings
+
+    if not os.path.exists(summary_path):
+        warnings.append(
+            f"'summary_shown' names {shown} but no gate-summary.md exists in "
+            f"{os.path.basename(phase_dir)}. The approved text is missing."
+        )
+        return warnings
+
+    try:
+        with open(summary_path, "rb") as sf:
+            actual = hashlib.sha256(sf.read()).hexdigest()
+    except OSError:
+        return warnings
+
+    recorded = str(data.get("summary_sha256", "")).strip().lower()
+    if recorded != actual:
+        warnings.append(
+            f"'summary_sha256' does not match gate-summary.md in "
+            f"{os.path.basename(phase_dir)} (recorded {recorded[:12]}..., "
+            f"file hashes to {actual[:12]}...). Either the summary was edited "
+            "after approval, or the digest was not taken from the rendered text."
+        )
+
+    return warnings
+
+
 def validate_file(file_path: str) -> list[str]:
     """Validate a JSON file against its schema. Returns warnings."""
     warnings = []
@@ -393,6 +440,8 @@ def validate_file(file_path: str) -> list[str]:
                 f"Missing 'summary_sha256' in {basename} (phase {data.get('phase')}). "
                 "Without the digest, a later edit to the summary is undetectable."
             )
+        else:
+            warnings.extend(_check_summary_digest(file_path, data))
 
     # Special validation for concept-anchor.json
     if basename == "concept-anchor.json":

--- a/tests/fixtures/gate_decision_phase1.json
+++ b/tests/fixtures/gate_decision_phase1.json
@@ -1,0 +1,7 @@
+{
+  "phase": 1,
+  "user_decision": "approved",
+  "recommendation": "GO",
+  "notes": "",
+  "decided_at": "2026-07-27T10:00:00Z"
+}

--- a/tests/fixtures/gate_decision_phase2_no_summary.json
+++ b/tests/fixtures/gate_decision_phase2_no_summary.json
@@ -1,0 +1,8 @@
+{
+  "phase": 2,
+  "user_decision": "approved",
+  "scope_revisions": 0,
+  "capability_revisions": 0,
+  "notes": "",
+  "decided_at": "2026-07-27T10:00:00Z"
+}

--- a/tests/fixtures/gate_summary_phase2_missing_sections.md
+++ b/tests/fixtures/gate_summary_phase2_missing_sections.md
@@ -1,0 +1,12 @@
+# What we are building
+
+A leaderboard for a single gym community.
+
+## What is in
+
+- **User Registration**: a member claims a handle and joins the board.
+- **Workout Logging**: a member records a completed workout.
+
+```json
+{"capabilities": {"functional": []}}
+```

--- a/tests/fixtures/gate_summary_phase2_uncovered_capability.md
+++ b/tests/fixtures/gate_summary_phase2_uncovered_capability.md
@@ -1,0 +1,19 @@
+# What we are building
+
+A leaderboard for a single gym community.
+
+## What is in
+
+- **User Registration**: a member claims a handle and joins the gym's board.
+
+## What is out
+
+Real-name profiles are out. The scope asks for anonymity.
+
+## Judgment calls
+
+- Registration and handle selection are one capability, not two.
+
+## Open questions
+
+- None.

--- a/tests/fixtures/valid_gate_decision_phase2.json
+++ b/tests/fixtures/valid_gate_decision_phase2.json
@@ -1,0 +1,12 @@
+{
+  "phase": 2,
+  "user_decision": "approved",
+  "scope_revisions": 0,
+  "capability_revisions": 0,
+  "checker_rounds": 1,
+  "checker_additions_accepted": 0,
+  "summary_shown": ".haytham/session/phase-2-what/gate-summary.md",
+  "summary_sha256": "a3f1c0de9b7e4a2f8c1d5e6b0a9384756fa2b1c0d9e8f7a6b5c4d3e2f1a0b9c8",
+  "notes": "",
+  "decided_at": "2026-07-27T10:00:00Z"
+}

--- a/tests/fixtures/valid_gate_summary_phase2.md
+++ b/tests/fixtures/valid_gate_summary_phase2.md
@@ -1,0 +1,21 @@
+# What we are building
+
+A leaderboard for a single gym community. Members log workouts under an anonymous handle and see where they stand against everyone else training in the same room.
+
+## What is in
+
+- **User Registration**: a member claims a handle and joins the gym's board. Serves "members can join with an anonymous handle".
+- **Workout Logging**: a member records a completed workout so it counts toward their standing. Serves "members can log workouts".
+
+## What is out
+
+Real-name profiles and social following are out. The scope asks for anonymity, and a follow graph would pull identity back in through the side door.
+
+## Judgment calls
+
+- Registration and handle selection are one capability, not two. A member does not experience picking a handle as a separate step from joining.
+- Logging does not validate that a workout actually happened. Verification is a trust problem, not an MVP problem, and the scope does not ask for it.
+
+## Open questions
+
+- The scope does not say whether a handle can be changed after it is claimed. Assumed no, because a changing handle breaks the standing history.

--- a/tests/fixtures/valid_gate_summary_phase3.md
+++ b/tests/fixtures/valid_gate_summary_phase3.md
@@ -1,0 +1,21 @@
+# How we are building it
+
+A small web app with a hosted database behind it. Nothing runs on your own hardware, and there is no background processing to babysit.
+
+## The stack
+
+- **Supabase** (BUY): database, auth, and hosting in one service, so there is one bill and one thing to learn.
+- **OpenAI API** (BUY): inference for the matching step. Building this in-house is a research project, not an MVP.
+
+## Decisions that matter
+
+- Standings are computed when the board is read, not on a schedule. Simpler to operate, and the numbers are never stale. The alternative, a nightly job, was rejected because it adds a scheduler to a system that otherwise has no background work.
+- Handles live in the same database as workouts. Splitting anonymity into a separate store was rejected: it doubles the operational surface for a gym-sized member list.
+
+## What this costs
+
+$0 to $50 a month, and roughly 2 to 3 days of integration work. Supabase is free until the database passes its free-tier size, which this member count will not reach in the first year.
+
+## Unknowns to resolve before building
+
+- What ranking rule handles ties and recent activity fairly? This blocks the leaderboard capability.

--- a/tests/test_plugin_sanity.py
+++ b/tests/test_plugin_sanity.py
@@ -8,6 +8,7 @@ Tests cover:
 5. Marketplace JSON validation
 """
 
+import hashlib
 import json
 import os
 import re
@@ -611,12 +612,67 @@ class TestSchemaValidation:
         warnings = validate_file(str(dst))
         assert any("cap: 600" in w for w in warnings)
 
+    def _gate_decision_with_summary(self, tmp_path, summary_text):
+        """Write a phase-2 gate decision whose digest matches the summary beside it."""
+        phase_dir = tmp_path / ".haytham" / "session" / "phase-2-what"
+        phase_dir.mkdir(parents=True)
+        (phase_dir / "gate-summary.md").write_text(summary_text)
+        decision = json.loads(
+            (FIXTURES_DIR / "valid_gate_decision_phase2.json").read_text()
+        )
+        decision["summary_sha256"] = hashlib.sha256(
+            summary_text.encode()
+        ).hexdigest()
+        dst = phase_dir / "gate-decision.json"
+        dst.write_text(json.dumps(decision))
+        return dst
+
     def test_valid_gate_decision_phase2(self, tmp_path):
+        summary = (FIXTURES_DIR / "valid_gate_summary_phase2.md").read_text()
+        dst = self._gate_decision_with_summary(tmp_path, summary)
+        warnings = validate_file(str(dst))
+        assert not warnings, f"Unexpected warnings: {warnings}"
+
+    def test_gate_decision_digest_mismatch(self, tmp_path):
+        """An edit to the summary after approval must be detectable."""
+        summary = (FIXTURES_DIR / "valid_gate_summary_phase2.md").read_text()
+        dst = self._gate_decision_with_summary(tmp_path, summary)
+        (dst.parent / "gate-summary.md").write_text(summary + "\nSnuck in later.\n")
+        warnings = validate_file(str(dst))
+        assert any("does not match gate-summary.md" in w for w in warnings)
+
+    def test_gate_decision_summary_file_missing(self, tmp_path):
+        """A decision naming a summary that is not on disk is a broken record."""
         dst = tmp_path / ".haytham" / "session" / "phase-2-what" / "gate-decision.json"
         dst.parent.mkdir(parents=True)
         dst.write_text((FIXTURES_DIR / "valid_gate_decision_phase2.json").read_text())
         warnings = validate_file(str(dst))
-        assert not warnings, f"Unexpected warnings: {warnings}"
+        assert any("no gate-summary.md exists" in w for w in warnings)
+
+    def test_gate_decision_phase3_digest_checked(self, tmp_path):
+        """Phase 3 records the same provenance and gets the same check."""
+        phase_dir = tmp_path / ".haytham" / "session" / "phase-3-how"
+        phase_dir.mkdir(parents=True)
+        summary = (FIXTURES_DIR / "valid_gate_summary_phase3.md").read_text()
+        (phase_dir / "gate-summary.md").write_text(summary)
+        dst = phase_dir / "gate-decision.json"
+        dst.write_text(
+            json.dumps(
+                {
+                    "phase": 3,
+                    "user_decision": "approved",
+                    "summary_shown": ".haytham/session/phase-3-how/gate-summary.md",
+                    "summary_sha256": hashlib.sha256(summary.encode()).hexdigest(),
+                    "notes": "",
+                    "decided_at": "2026-07-27T10:00:00Z",
+                }
+            )
+        )
+        assert not validate_file(str(dst))
+
+        (phase_dir / "gate-summary.md").write_text(summary + "\nEdited.\n")
+        warnings = validate_file(str(dst))
+        assert any("does not match gate-summary.md" in w for w in warnings)
 
     def test_gate_decision_phase2_missing_summary(self, tmp_path):
         dst = tmp_path / ".haytham" / "session" / "phase-2-what" / "gate-decision.json"

--- a/tests/test_plugin_sanity.py
+++ b/tests/test_plugin_sanity.py
@@ -537,6 +537,104 @@ class TestSchemaValidation:
         assert any("CAP-F-003" in w for w in warnings)
         assert any("CAP-NF-001" in w for w in warnings)
 
+    def test_valid_gate_summary_phase2(self, tmp_path):
+        phase_dir = tmp_path / ".haytham" / "session" / "phase-2-what"
+        phase_dir.mkdir(parents=True)
+        (phase_dir / "capabilities.json").write_text(
+            (FIXTURES_DIR / "valid_capabilities.json").read_text()
+        )
+        dst = phase_dir / "gate-summary.md"
+        dst.write_text((FIXTURES_DIR / "valid_gate_summary_phase2.md").read_text())
+        warnings = validate_file(str(dst))
+        assert not warnings, f"Unexpected warnings: {warnings}"
+
+    def test_gate_summary_phase2_missing_sections(self, tmp_path):
+        dst = tmp_path / ".haytham" / "session" / "phase-2-what" / "gate-summary.md"
+        dst.parent.mkdir(parents=True)
+        dst.write_text(
+            (FIXTURES_DIR / "gate_summary_phase2_missing_sections.md").read_text()
+        )
+        warnings = validate_file(str(dst))
+        assert any("Missing section 'What is out'" in w for w in warnings)
+        assert any("Missing section 'Judgment calls'" in w for w in warnings)
+        assert any("Missing section 'Open questions'" in w for w in warnings)
+        assert any("Contains a JSON block" in w for w in warnings)
+
+    def test_gate_summary_phase2_uncovered_capability(self, tmp_path):
+        """Every functional capability being approved must be named in the summary."""
+        phase_dir = tmp_path / ".haytham" / "session" / "phase-2-what"
+        phase_dir.mkdir(parents=True)
+        (phase_dir / "capabilities.json").write_text(
+            (FIXTURES_DIR / "valid_capabilities.json").read_text()
+        )
+        dst = phase_dir / "gate-summary.md"
+        dst.write_text(
+            (FIXTURES_DIR / "gate_summary_phase2_uncovered_capability.md").read_text()
+        )
+        warnings = validate_file(str(dst))
+        assert any("Workout Logging" in w and "not mentioned" in w for w in warnings)
+        assert not any("User Registration" in w for w in warnings)
+
+    def test_gate_summary_phase2_coverage_skips_without_caps(self, tmp_path):
+        """Coverage check degrades gracefully when capabilities.json is absent."""
+        dst = tmp_path / ".haytham" / "session" / "phase-2-what" / "gate-summary.md"
+        dst.parent.mkdir(parents=True)
+        dst.write_text(
+            (FIXTURES_DIR / "gate_summary_phase2_uncovered_capability.md").read_text()
+        )
+        warnings = validate_file(str(dst))
+        assert not warnings, f"Unexpected warnings: {warnings}"
+
+    def test_valid_gate_summary_phase3(self, tmp_path):
+        dst = tmp_path / ".haytham" / "session" / "phase-3-how" / "gate-summary.md"
+        dst.parent.mkdir(parents=True)
+        dst.write_text((FIXTURES_DIR / "valid_gate_summary_phase3.md").read_text())
+        warnings = validate_file(str(dst))
+        assert not warnings, f"Unexpected warnings: {warnings}"
+
+    def test_gate_summary_phase3_missing_sections(self, tmp_path):
+        """Phase 3 required sections differ from phase 2, same filename."""
+        dst = tmp_path / ".haytham" / "session" / "phase-3-how" / "gate-summary.md"
+        dst.parent.mkdir(parents=True)
+        dst.write_text(
+            (FIXTURES_DIR / "valid_gate_summary_phase2.md").read_text()
+        )
+        warnings = validate_file(str(dst))
+        assert any("Missing section 'The stack'" in w for w in warnings)
+        assert any("Missing section 'Decisions that matter'" in w for w in warnings)
+
+    def test_gate_summary_word_cap(self, tmp_path):
+        dst = tmp_path / ".haytham" / "session" / "phase-3-how" / "gate-summary.md"
+        dst.parent.mkdir(parents=True)
+        base = (FIXTURES_DIR / "valid_gate_summary_phase3.md").read_text()
+        dst.write_text(base + "\n" + ("padding " * 600))
+        warnings = validate_file(str(dst))
+        assert any("cap: 600" in w for w in warnings)
+
+    def test_valid_gate_decision_phase2(self, tmp_path):
+        dst = tmp_path / ".haytham" / "session" / "phase-2-what" / "gate-decision.json"
+        dst.parent.mkdir(parents=True)
+        dst.write_text((FIXTURES_DIR / "valid_gate_decision_phase2.json").read_text())
+        warnings = validate_file(str(dst))
+        assert not warnings, f"Unexpected warnings: {warnings}"
+
+    def test_gate_decision_phase2_missing_summary(self, tmp_path):
+        dst = tmp_path / ".haytham" / "session" / "phase-2-what" / "gate-decision.json"
+        dst.parent.mkdir(parents=True)
+        dst.write_text(
+            (FIXTURES_DIR / "gate_decision_phase2_no_summary.json").read_text()
+        )
+        warnings = validate_file(str(dst))
+        assert any("summary_shown" in w for w in warnings)
+
+    def test_gate_decision_phase1_needs_no_summary(self, tmp_path):
+        """Phase 1 already ships prose, so it carries no summary pointer."""
+        dst = tmp_path / ".haytham" / "session" / "phase-1-why" / "gate-decision.json"
+        dst.parent.mkdir(parents=True)
+        dst.write_text((FIXTURES_DIR / "gate_decision_phase1.json").read_text())
+        warnings = validate_file(str(dst))
+        assert not warnings, f"Unexpected warnings: {warnings}"
+
     def test_valid_scope_risk(self, tmp_path):
         dst = tmp_path / ".haytham" / "session" / "phase-1-why" / "concept-anchor.json"
         dst.parent.mkdir(parents=True)


### PR DESCRIPTION
Closes #72.

## Problem

Gates 2 and 3 asked the founder to approve work whose only on-disk form was JSON. The commands did render a digest inline, but it was composed on the fly by whichever session was orchestrating: quality varied, and it was never written to disk. `gate-decision.json` therefore did not say what the founder actually read. Phase 1 never had this problem because `validation-report.md` is already prose.

## Approach

The agent that owns the JSON writes `gate-summary.md` in the same pass. It is the only actor that knows the cuts it made and the questions it could not resolve, and none of that lives in the JSON, so a deterministic renderer over the JSON could not produce it. Precedent: `report-synthesizer` already emits `validation-report.md` and `validation-report.json` together.

- `capability-modeler` writes `phase-2-what/gate-summary.md`: what is in, what is out, judgment calls, open questions
- `architect` writes `phase-3-how/gate-summary.md`: the stack, decisions that matter, what this costs, unknowns to resolve
- Both reuse the existing founder-persona tone rule rather than inventing a second standard
- `specify`, `design` and the `haytham` mirrors render the file verbatim at the gate and `shasum -a 256` it before asking
- `gate-decision.json` for phases 2 and 3 gains `summary_shown` and `summary_sha256`, so the approval names the exact text and a later edit is detectable
- `validate_schema.py` gains a path-aware `gate-summary.md` branch (both phases share the basename): required sections per phase, no JSON fence, 600 word cap, and a phase 2 check that every functional capability is named
- `build.md` excludes it from the exported context, alongside the previously unlisted `capability-review.json`

## Verification

- `pytest tests/test_plugin_sanity.py`: 198 passed, 8 skipped, including 10 new cases over 7 new fixtures
- The PostToolUse hook path was driven directly with real tool-input JSON: a good summary is silent; a missing capability, wrong-phase sections, and a missing `summary_shown` each warn

**Not verified:** the end-to-end pipeline run. Nothing here yet proves the agents actually emit the file rather than just being instructed to. Run `/haytham:specify` on a session with phase 1 complete and confirm `phase-2-what/gate-summary.md` appears, is populated rather than template placeholders, and that the checker loop rewrites it after an accepted addition.

## Note

This branch also carries the in-flight `capability-checker` work for #71. It is interleaved in the same command files and could not be split cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TvpSr3SfrPpDCGGX6DNXo
